### PR TITLE
Add --prepare flag to faasd install

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,27 @@ You can run this tutorial on your Raspberry Pi, or adapt the steps for a regular
 
 * [faasd - lightweight Serverless for your Raspberry Pi](https://blog.alexellis.io/faasd-for-lightweight-serverless/)
 
-## Hacking (build from source)
+
+### Either download binaries
+
+```sh
+# For x86_64
+sudo curl -fSLs "https://github.com/alexellis/faasd/releases/download/0.4.4/faasd" \
+    -o "/usr/local/bin/faasd" \
+    && sudo chmod a+x "/usr/local/bin/faasd"
+
+# armhf
+sudo curl -fSLs "https://github.com/alexellis/faasd/releases/download/0.4.4/faasd-armhf" \
+    -o "/usr/local/bin/faasd" \
+    && sudo chmod a+x "/usr/local/bin/faasd"
+
+# arm64
+sudo curl -fSLs "https://github.com/alexellis/faasd/releases/download/0.4.4/faasd-arm64" \
+    -o "/usr/local/bin/faasd" \
+    && sudo chmod a+x "/usr/local/bin/faasd"
+```
+
+## Or for hacking, you can build from source
 
 Install the CNI plugins:
 
@@ -111,29 +131,17 @@ cd $GOPATH/src/github.com/alexellis/faasd
 go build
 
 # Install with systemd
-# sudo ./faasd install
-
-# Or run interactively
-# sudo ./faasd up
+sudo ./faasd install
 ```
 
-### Build and run (binaries)
+Now you can access faasd on `localhost:8080`.
+
+For development do not run `faasd up` manually unless you are working in development.
 
 ```sh
-# For x86_64
-sudo curl -fSLs "https://github.com/alexellis/faasd/releases/download/0.4.4/faasd" \
-    -o "/usr/local/bin/faasd" \
-    && sudo chmod a+x "/usr/local/bin/faasd"
-
-# armhf
-sudo curl -fSLs "https://github.com/alexellis/faasd/releases/download/0.4.4/faasd-armhf" \
-    -o "/usr/local/bin/faasd" \
-    && sudo chmod a+x "/usr/local/bin/faasd"
-
-# arm64
-sudo curl -fSLs "https://github.com/alexellis/faasd/releases/download/0.4.4/faasd-arm64" \
-    -o "/usr/local/bin/faasd" \
-    && sudo chmod a+x "/usr/local/bin/faasd"
+sudo ./faasd install --prepare  # Only creates secrets, skipping systemd configuration
+sudo cp -r /run/faasd/secrets . # Copy in generated secrets
+sudo ./faasd up
 ```
 
 ### At run-time
@@ -163,6 +171,7 @@ Since faas-containerd uses containerd heavily it is not running as a container, 
 * basic-auth
 
     You will then need to get the basic-auth password, it is written to `/run/faasd/secrets/basic-auth-password` if you followed the above instructions.
+
 The default Basic Auth username is `admin`, which is written to `/run/faasd/secrets/basic-auth-user`, if you wish to use a non-standard user then create this file and add your username (no newlines or other characters) 
 
 #### Installation with systemd

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -13,7 +13,7 @@ const WelcomeMessage = "Welcome to faasd"
 func init() {
 	rootCommand.AddCommand(versionCmd)
 	rootCommand.AddCommand(upCmd)
-	rootCommand.AddCommand(installCmd)
+	rootCommand.AddCommand(makeInstallCmd())
 }
 
 var (

--- a/cmd/up.go
+++ b/cmd/up.go
@@ -57,6 +57,8 @@ const secretMountDir = "/run/secrets"
 
 func runUp(_ *cobra.Command, _ []string) error {
 
+	wd, _ := os.Getwd()
+
 	clientArch, clientOS := env.GetClientArch()
 
 	if clientOS != "Linux" {
@@ -84,7 +86,7 @@ func runUp(_ *cobra.Command, _ []string) error {
 		return errors.Wrap(makeNetworkErr, "error creating network config")
 	}
 
-	services := makeServiceDefinitions(clientSuffix)
+	services := makeServiceDefinitions(wd, clientSuffix)
 
 	start := time.Now()
 	supervisor, err := pkg.NewSupervisor("/run/containerd/containerd.sock")
@@ -199,8 +201,7 @@ func makeFile(filePath, fileContents string) error {
 	}
 }
 
-func makeServiceDefinitions(archSuffix string) []pkg.Service {
-	wd, _ := os.Getwd()
+func makeServiceDefinitions(wd, archSuffix string) []pkg.Service {
 
 	return []pkg.Service{
 		pkg.Service{

--- a/main.go
+++ b/main.go
@@ -15,8 +15,10 @@ var (
 )
 
 func main() {
+
 	if err := cmd.Execute(Version, GitCommit); err != nil {
 		os.Exit(1)
 	}
+
 	return
 }


### PR DESCRIPTION
Signed-off-by: Alex Ellis (OpenFaaS Ltd) <alexellis2@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Add --prepare flag to faasd install

* This flag enables a better flow for development, now that the
data directory is hard-coded.

## Motivation and Context

A note mentioned by @Waterdrips on Slack after hard-coding the data path to `/run/faasd`

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

```sh
go build && sudo ./faasd install --prepare && sudo cp -r /run/faasd/secrets . && sudo ./faasd up
2020/01/05 18:47:21 File exists: "/run/faasd/secrets/basic-auth-password"
2020/01/05 18:47:21 File exists: "/run/faasd/secrets/basic-auth-user"
2020/01/05 18:47:21 File exists: "/run/faasd/secrets/basic-auth-password"
2020/01/05 18:47:21 File exists: "/run/faasd/secrets/basic-auth-user"

sudo find secrets/
secrets/
secrets/basic-auth-user
secrets/basic-auth-password
```