### PR TITLE
Improve developer workflow with systemd flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,16 +152,45 @@ The default Basic Auth username is `admin`, which is written to `/run/faasd/secr
 * `journalctl -u faasd` - faasd systemd logs
 * `journalctl -u faas-containerd` - faas-containerd systemd logs
 
+#### Changing your basic-auth username and password
+
+By default `faasd install` creates the basic auth files in the /run/faasd/secrets directory. If you wish to change these 
+secrets simply edit (or create) these files and re-load the systemd services
+
+To regenerate a random password you only need to remove the `basic-auth-password` file. To set your own password just 
+create this file with your password in it without extra whitespace or newlines.
+
+For a non-default username (default is `admin`) edit/create the basic-auth-user file with your username.
+
+
+```
+sudo systemctl stop faas-containerd && sudo systemctl start faas-containerd
+sudo systemctl stop faasd && sudo systemctl start faasd
+```
+
+#### Developing faasd
+
+It may be easier to run faasd using the `faasd up` command when developing. This allows you to build and run faasd 
+without installing using `faasd install` command to start systemd services.
+
+There are 2 flags that may be useful in this case, 
+
+* `faasd install --prepare` will create the /run/faasd directory, basic auth files and copy in some config 
+without installing and starting the systemd services
+
+* `faasd up --work-dir /run/faasd/` will allow you to run faasd from anywhere, like on your go path, so you can build and
+run your new faasd binaries and point them at the correct "working directory"
+
 ### Appendix
 
 Removing containers:
 
 ```sh
-echo faas-containerd gateway prometheus | xargs sudo ctr task rm -f
+echo faas-containerd gateway prometheus nats queue-worker | xargs sudo ctr task rm -f
 
-echo faas-containerd gateway prometheus | xargs sudo ctr container rm
+echo faas-containerd gateway prometheus nats queue-worker | xargs sudo ctr container rm
 
-echo faas-containerd gateway prometheus | xargs sudo ctr snapshot rm
+echo faas-containerd gateway prometheus nats queue-worker | xargs sudo ctr snapshot rm
 ```
 
 ## Links

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -7,12 +7,13 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// WelcomeMessage to introduce ofc-bootstrap
-const WelcomeMessage = "Welcome to faasd"
-
 func init() {
 	rootCommand.AddCommand(versionCmd)
+
+	upCmd.Flags().String("work-dir", "", "--work-dir can be used to tell faasd to use a specific directory, rather than the current directory")
 	rootCommand.AddCommand(upCmd)
+
+	installCmd.Flags().Bool("prepare", false, "prepare for installation only, dont start or enable systemd services")
 	rootCommand.AddCommand(installCmd)
 }
 

--- a/pkg/auth.go
+++ b/pkg/auth.go
@@ -1,0 +1,33 @@
+package pkg
+
+import (
+	"github.com/sethvargo/go-password/password"
+)
+
+func MakeBasicAuthFiles(wd string) error {
+
+	dirErr := EnsureWorkingDir(wd)
+	if dirErr != nil {
+		return dirErr
+	}
+
+	pwdFile := wd + "/basic-auth-password"
+	authPassword, err := password.Generate(63, 10, 0, false, true)
+
+	if err != nil {
+		return err
+	}
+
+	err = MakeFile(pwdFile, authPassword)
+	if err != nil {
+		return err
+	}
+
+	userFile := wd + "/basic-auth-user"
+	err = MakeFile(userFile, "admin")
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/pkg/filesystem.go
+++ b/pkg/filesystem.go
@@ -1,0 +1,61 @@
+package pkg
+
+import (
+	"fmt"
+	"io"
+	"io/ioutil"
+	"log"
+	"os"
+	"path"
+)
+
+func MakeFile(filePath, fileContents string) error {
+	_, err := os.Stat(filePath)
+	if err == nil {
+		log.Printf("File exists: %q\n", filePath)
+		return nil
+	} else if os.IsNotExist(err) {
+		log.Printf("Writing to: %q\n", filePath)
+		return ioutil.WriteFile(filePath, []byte(fileContents), 0644)
+	} else {
+		return err
+	}
+}
+
+func EnsureWorkingDir(folder string) error {
+	if _, err := os.Stat(folder); err != nil {
+		err = os.MkdirAll(folder, 0600)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func CopyFile(source, destFolder string) error {
+	file, err := os.Open(source)
+	if err != nil {
+		return err
+
+	}
+	defer file.Close()
+
+	out, err := os.Create(path.Join(destFolder, source))
+	if err != nil {
+		return err
+	}
+	defer out.Close()
+
+	_, err = io.Copy(out, file)
+
+	return err
+}
+
+func BinaryExists(folder, name string) error {
+	findPath := path.Join(folder, name)
+	if _, err := os.Stat(findPath); err != nil {
+		return fmt.Errorf("unable to stat %s, install this binary before continuing", findPath)
+	}
+	return nil
+}


### PR DESCRIPTION
# Description
<!--- Describe your changes in detail -->

As the working directory was moved into /run/faasd we were
unable to run faasd from our current working directory as
various paths were hard coded to this new directory and the
faasd command assumed it was being run from there.

Fixes #16 

Also there is some addition to the README about resetting/changing the basic auth password/user
Signed-off-by: Alistair Hey <alistair@heyal.co.uk>

<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change **this is required**
Partly #16

When developing its easier to run from the go path as that
is where we build the binary. This commit allows passing a
flag to the install command to install only the required
files into the /run/faasd directory, and adds a flag to the
up command that allows us to fake running from that directory


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
This has been tested by running install without the new flag,
the services get created and installed. These were removed,
disabled and the /run/faasd directory was deleted. Then
install was run with the new --install-services flag set to
false, which should only create and install the files into the
/run/faasd directory.

The up command was tested with the new --work-dir flag pointing
at the /run/faasd directory and it worked when $PWD was not
/run/faasd. (faas-containerd run manually in another terminal)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Commits:

- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] My commit message has a body and describe how this was tested and why it is required.
- [x] I have signed-off my commits with `git commit -s` for the Developer Certificate of Origin (DCO)

Code:

- [x] My code follows the code style of this project.
- [ ] I have added tests to cover my changes.

Docs:

- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
