### PR TITLE
Enable labeling containers

### DIFF
--- a/pkg/provider/handlers/deploy.go
+++ b/pkg/provider/handlers/deploy.go
@@ -107,6 +107,7 @@ func deploy(ctx context.Context, req types.FunctionDeployment, client *container
 			oci.WithCapabilities([]string{"CAP_NET_RAW"}),
 			oci.WithMounts(mounts),
 			oci.WithEnv(envs)),
+		containerd.WithContainerLabels(*req.Labels),
 	)
 
 	if err != nil {

--- a/pkg/provider/handlers/read.go
+++ b/pkg/provider/handlers/read.go
@@ -26,6 +26,7 @@ func MakeReadHandler(client *containerd.Client) func(w http.ResponseWriter, r *h
 				Image:     function.image,
 				Replicas:  uint64(function.replicas),
 				Namespace: function.namespace,
+				Labels:    &function.labels,
 			})
 		}
 


### PR DESCRIPTION
Enabling the faasd-provider to label containers

Signed-off-by: Martin Dekov <mvdekov@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Horizontal slice in order to enable labeling containers with the `faas-cli` and through the `UI`.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change **this is required**

Closes #40 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Deployed figlet through:
* UI 
* CLI
with label `{"label":"saws"}` (not very professional) resulted in this from `/system/functions`:
```
[{"name":"figlet","image":"docker.io/functions/figlet:0.13.0","invocationCount":0,"replicas":1,"envProcess":"","availableReplicas":0,"labels":{"label":"saws"},"annotations":null,"namespace":"openfaas-fn"}]
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Commits:

- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] (1/2) My commit message has a body and (NOT THIS) -> describe how this was tested and why it is required.
- [x] I have signed-off my commits with `git commit -s` for the Developer Certificate of Origin (DCO)

Code:

- [x] My code follows the code style of this project.
- [ ] I have added tests to cover my changes.

Docs:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
