### PR TITLE
Makefile: added labels to test-e2e

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,9 +37,10 @@ prepare-test:
 .PHONY: test-e2e
 test-e2e:
 	sudo cat /var/lib/faasd/secrets/basic-auth-password | /usr/local/bin/faas-cli login --password-stdin
-	/usr/local/bin/faas-cli store deploy figlet --env write_timeout=1s --env read_timeout=1s
+	/usr/local/bin/faas-cli store deploy figlet --env write_timeout=1s --env read_timeout=1s --label testing=true
 	sleep 5
 	/usr/local/bin/faas-cli list -v
+	/usr/local/bin/faas-cli describe figlet | grep testing
 	uname | /usr/local/bin/faas-cli invoke figlet
 	uname | /usr/local/bin/faas-cli invoke figlet --async
 	sleep 10


### PR DESCRIPTION
Added label to test and check they are being returned on `describe`

## Description
Added `-l testing=true` to deploy command and then run a `describe` followed by `grep testing`
## Motivation and Context

Fixes issue #52 


## How Has This Been Tested?
Run the test and verified it passes:
```make test-e2e
sudo cat /var/lib/faasd/secrets/basic-auth-password | /usr/local/bin/faas-cli login --password-stdin
Calling the OpenFaaS server to validate the credentials...
WARNING! Communication is not secure, please consider using HTTPS. Letsencrypt.org offers free SSL/TLS certificates.
credentials saved for admin http://127.0.0.1:8080
/usr/local/bin/faas-cli store deploy figlet --env write_timeout=1s --env read_timeout=1s -l testing=true
WARNING! Communication is not secure, please consider using HTTPS. Letsencrypt.org offers free SSL/TLS certificates.
Function figlet already exists, attempting rolling-update.

Deployed. 200 OK.
URL: http://127.0.0.1:8080/function/figlet

sleep 5
/usr/local/bin/faas-cli list -v
Function                      	Image                                   	Invocations    	Replicas
stronghash                    	docker.io/functions/alpine:latest       	0              	1    
url-ping                      	docker.io/alexellis/faas-url-ping:0.2   	0              	1    
f1                            	docker.io/functions/figlet:latest-armhf 	0              	0    
figlet                        	docker.io/functions/figlet:0.13.0       	2              	1    
nodejs-echo                   	docker.io/alexellis/faas-nodejs-echo:0.1	0              	1    
ruby-echo                     	docker.io/alexellis/ruby-echo:0.2       	0              	1    
shrink-image                  	docker.io/functions/resizer:0.1         	0              	1    
/usr/local/bin/faas-cli describe figlet | grep testing
Labels:              testing : true
uname | /usr/local/bin/faas-cli invoke figlet
 _     _                  
| |   (_)_ __  _   ___  __
| |   | | '_ \| | | \ \/ /
| |___| | | | | |_| |>  < 
|_____|_|_| |_|\__,_/_/\_\
                          
uname | /usr/local/bin/faas-cli invoke figlet --async
Function submitted asynchronously.
sleep 10
/usr/local/bin/faas-cli list -v
Function                      	Image                                   	Invocations    	Replicas
ruby-echo                     	docker.io/alexellis/ruby-echo:0.2       	0              	1    
shrink-image                  	docker.io/functions/resizer:0.1         	0              	1    
stronghash                    	docker.io/functions/alpine:latest       	0              	1    
url-ping                      	docker.io/alexellis/faas-url-ping:0.2   	0              	1    
f1                            	docker.io/functions/figlet:latest-armhf 	0              	0    
figlet                        	docker.io/functions/figlet:0.13.0       	4              	1    
nodejs-echo                   	docker.io/alexellis/faas-nodejs-echo:0.1	0              	1    
/usr/local/bin/faas-cli remove figlet
Deleting: figlet.
Removing old function.
sleep 3
/usr/local/bin/faas-cli list
Function                      	Invocations    	Replicas
stronghash                    	0              	1    
url-ping                      	0              	1    
f1                            	0              	0    
nodejs-echo                   	0              	1    
ruby-echo                     	0              	1    
shrink-image                  	0              	1    
```

Then changed the grep string and verified it failed:
```make test-e2e
sudo cat /var/lib/faasd/secrets/basic-auth-password | /usr/local/bin/faas-cli login --password-stdin
Calling the OpenFaaS server to validate the credentials...
WARNING! Communication is not secure, please consider using HTTPS. Letsencrypt.org offers free SSL/TLS certificates.
credentials saved for admin http://127.0.0.1:8080
/usr/local/bin/faas-cli store deploy figlet --env write_timeout=1s --env read_timeout=1s -l testing=true
WARNING! Communication is not secure, please consider using HTTPS. Letsencrypt.org offers free SSL/TLS certificates.
Function figlet already exists, attempting rolling-update.

Deployed. 200 OK.
URL: http://127.0.0.1:8080/function/figlet

sleep 5
/usr/local/bin/faas-cli list -v
Function                      	Image                                   	Invocations    	Replicas
ruby-echo                     	docker.io/alexellis/ruby-echo:0.2       	0              	1    
shrink-image                  	docker.io/functions/resizer:0.1         	0              	1    
stronghash                    	docker.io/functions/alpine:latest       	0              	1    
url-ping                      	docker.io/alexellis/faas-url-ping:0.2   	0              	1    
f1                            	docker.io/functions/figlet:latest-armhf 	0              	0    
figlet                        	docker.io/functions/figlet:0.13.0       	4              	1    
nodejs-echo                   	docker.io/alexellis/faas-nodejs-echo:0.1	0              	1    
/usr/local/bin/faas-cli describe figlet | grep non-existing-testing
make: *** [Makefile:43: test-e2e] Error 1
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Commits:

- [X] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [X] My commit message has a body and describe how this was tested and why it is required.
- [X] I have signed-off my commits with `git commit -s` for the Developer Certificate of Origin (DCO)

Code:

- [X] My code follows the code style of this project.
- [] I have added tests to cover my changes.

Docs:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
