### PR TITLE
Always pull images by default

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -14,7 +14,7 @@ func init() {
 	rootCommand.AddCommand(versionCmd)
 	rootCommand.AddCommand(upCmd)
 	rootCommand.AddCommand(installCmd)
-	rootCommand.AddCommand(providerCmd)
+	rootCommand.AddCommand(makeProviderCmd())
 	rootCommand.AddCommand(collectCmd)
 }
 

--- a/cmd/up.go
+++ b/cmd/up.go
@@ -14,8 +14,8 @@ import (
 
 	"github.com/pkg/errors"
 
-	"github.com/openfaas/faasd/pkg"
 	"github.com/alexellis/k3sup/pkg/env"
+	"github.com/openfaas/faasd/pkg"
 	"github.com/sethvargo/go-password/password"
 	"github.com/spf13/cobra"
 )
@@ -116,6 +116,7 @@ func runUp(_ *cobra.Command, _ []string) error {
 			log.Println(fileErr)
 			return
 		}
+
 		host := ""
 		lines := strings.Split(string(fileData), "\n")
 		for _, line := range lines {

--- a/cmd/up.go
+++ b/cmd/up.go
@@ -173,7 +173,7 @@ func makeServiceDefinitions(archSuffix string) []pkg.Service {
 	wd, _ := os.Getwd()
 
 	return []pkg.Service{
-		pkg.Service{
+		{
 			Name:  "basic-auth-plugin",
 			Image: "docker.io/openfaas/basic-auth-plugin:0.18.10" + archSuffix,
 			Env: []string{
@@ -183,11 +183,11 @@ func makeServiceDefinitions(archSuffix string) []pkg.Service {
 				"pass_filename=basic-auth-password",
 			},
 			Mounts: []pkg.Mount{
-				pkg.Mount{
+				{
 					Src:  path.Join(path.Join(wd, "secrets"), "basic-auth-password"),
 					Dest: path.Join(containerSecretMountDir, "basic-auth-password"),
 				},
-				pkg.Mount{
+				{
 					Src:  path.Join(path.Join(wd, "secrets"), "basic-auth-user"),
 					Dest: path.Join(containerSecretMountDir, "basic-auth-user"),
 				},
@@ -195,26 +195,26 @@ func makeServiceDefinitions(archSuffix string) []pkg.Service {
 			Caps: []string{"CAP_NET_RAW"},
 			Args: nil,
 		},
-		pkg.Service{
+		{
 			Name:  "nats",
 			Env:   []string{""},
 			Image: "docker.io/library/nats-streaming:0.11.2",
 			Caps:  []string{},
 			Args:  []string{"/nats-streaming-server", "-m", "8222", "--store=memory", "--cluster_id=faas-cluster"},
 		},
-		pkg.Service{
+		{
 			Name:  "prometheus",
 			Env:   []string{},
 			Image: "docker.io/prom/prometheus:v2.14.0",
 			Mounts: []pkg.Mount{
-				pkg.Mount{
+				{
 					Src:  path.Join(wd, "prometheus.yml"),
 					Dest: "/etc/prometheus/prometheus.yml",
 				},
 			},
 			Caps: []string{"CAP_NET_RAW"},
 		},
-		pkg.Service{
+		{
 			Name: "gateway",
 			Env: []string{
 				"basic_auth=true",
@@ -232,18 +232,18 @@ func makeServiceDefinitions(archSuffix string) []pkg.Service {
 			},
 			Image: "docker.io/openfaas/gateway:0.18.8" + archSuffix,
 			Mounts: []pkg.Mount{
-				pkg.Mount{
+				{
 					Src:  path.Join(path.Join(wd, "secrets"), "basic-auth-password"),
 					Dest: path.Join(containerSecretMountDir, "basic-auth-password"),
 				},
-				pkg.Mount{
+				{
 					Src:  path.Join(path.Join(wd, "secrets"), "basic-auth-user"),
 					Dest: path.Join(containerSecretMountDir, "basic-auth-user"),
 				},
 			},
 			Caps: []string{"CAP_NET_RAW"},
 		},
-		pkg.Service{
+		{
 			Name: "queue-worker",
 			Env: []string{
 				"faas_nats_address=nats",
@@ -258,11 +258,11 @@ func makeServiceDefinitions(archSuffix string) []pkg.Service {
 			},
 			Image: "docker.io/openfaas/queue-worker:0.9.0",
 			Mounts: []pkg.Mount{
-				pkg.Mount{
+				{
 					Src:  path.Join(path.Join(wd, "secrets"), "basic-auth-password"),
 					Dest: path.Join(containerSecretMountDir, "basic-auth-password"),
 				},
-				pkg.Mount{
+				{
 					Src:  path.Join(path.Join(wd, "secrets"), "basic-auth-user"),
 					Dest: path.Join(containerSecretMountDir, "basic-auth-user"),
 				},

--- a/pkg/provider/handlers/delete.go
+++ b/pkg/provider/handlers/delete.go
@@ -8,12 +8,12 @@ import (
 	"log"
 	"net/http"
 
-	cninetwork "github.com/openfaas/faasd/pkg/cninetwork"
-	"github.com/openfaas/faasd/pkg/service"
 	"github.com/containerd/containerd"
 	"github.com/containerd/containerd/namespaces"
 	gocni "github.com/containerd/go-cni"
 	"github.com/openfaas/faas/gateway/requests"
+	cninetwork "github.com/openfaas/faasd/pkg/cninetwork"
+	"github.com/openfaas/faasd/pkg/service"
 )
 
 func MakeDeleteHandler(client *containerd.Client, cni gocni.CNI) func(w http.ResponseWriter, r *http.Request) {

--- a/pkg/provider/handlers/update.go
+++ b/pkg/provider/handlers/update.go
@@ -8,15 +8,15 @@ import (
 	"log"
 	"net/http"
 
-	"github.com/openfaas/faasd/pkg/cninetwork"
-	"github.com/openfaas/faasd/pkg/service"
 	"github.com/containerd/containerd"
 	"github.com/containerd/containerd/namespaces"
 	gocni "github.com/containerd/go-cni"
 	"github.com/openfaas/faas-provider/types"
+	"github.com/openfaas/faasd/pkg/cninetwork"
+	"github.com/openfaas/faasd/pkg/service"
 )
 
-func MakeUpdateHandler(client *containerd.Client, cni gocni.CNI, secretMountPath string) func(w http.ResponseWriter, r *http.Request) {
+func MakeUpdateHandler(client *containerd.Client, cni gocni.CNI, secretMountPath string, alwaysPull bool) func(w http.ResponseWriter, r *http.Request) {
 
 	return func(w http.ResponseWriter, r *http.Request) {
 
@@ -68,7 +68,7 @@ func MakeUpdateHandler(client *containerd.Client, cni gocni.CNI, secretMountPath
 			return
 		}
 
-		deployErr := deploy(ctx, req, client, cni, secretMountPath)
+		deployErr := deploy(ctx, req, client, cni, secretMountPath, alwaysPull)
 		if deployErr != nil {
 			log.Printf("[Update] error deploying %s, error: %s\n", name, deployErr)
 			http.Error(w, deployErr.Error(), http.StatusBadRequest)

--- a/pkg/supervisor.go
+++ b/pkg/supervisor.go
@@ -8,13 +8,13 @@ import (
 	"os"
 	"path"
 
-	"github.com/openfaas/faasd/pkg/cninetwork"
-	"github.com/openfaas/faasd/pkg/service"
 	"github.com/containerd/containerd"
 	"github.com/containerd/containerd/cio"
 	"github.com/containerd/containerd/containers"
 	"github.com/containerd/containerd/oci"
 	gocni "github.com/containerd/go-cni"
+	"github.com/openfaas/faasd/pkg/cninetwork"
+	"github.com/openfaas/faasd/pkg/service"
 
 	"github.com/containerd/containerd/namespaces"
 	"github.com/opencontainers/runtime-spec/specs-go"
@@ -24,7 +24,8 @@ const (
 	defaultSnapshotter         = "overlayfs"
 	workingDirectoryPermission = 0644
 	// faasdNamespace is the containerd namespace services are created
-	faasdNamespace = "default"
+	faasdNamespace         = "default"
+	faasServicesPullAlways = false
 )
 
 type Service struct {
@@ -88,7 +89,7 @@ func (s *Supervisor) Start(svcs []Service) error {
 	for _, svc := range svcs {
 		fmt.Printf("Preparing: %s with image: %s\n", svc.Name, svc.Image)
 
-		img, err := service.PrepareImage(ctx, s.client, svc.Image, defaultSnapshotter)
+		img, err := service.PrepareImage(ctx, s.client, svc.Image, defaultSnapshotter, faasServicesPullAlways)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
The behaviour prior to this patch caused some confusion for
users since they expected a behaviour like Swarm / Kubernetes
which always pulls images by default, even if cached. I've tested
the change and it is working as expected. By default images are
always pulled upon deployment.

To revert to the prior behaviour, simply add to faasd up:
--pull-policy=IfNotPresent
