### PR TITLE
Use an unbuffered log msg channel

### DIFF
--- a/pkg/logs/requestor.go
+++ b/pkg/logs/requestor.go
@@ -49,7 +49,7 @@ func (r *requester) Query(ctx context.Context, req logs.Request) (<-chan logs.Me
 	// call start and get the stdout prior to streaming so that we can return a meaningful
 	// error for as long as possible. If the cmd starts correctly, we are highly likely to
 	// succeed anyway
-	msgs := make(chan logs.Message, 100)
+	msgs := make(chan logs.Message)
 	go streamLogs(ctx, cmd, stdout, msgs)
 	go logErrOut(stderr)
 
@@ -102,10 +102,6 @@ func buildCmd(ctx context.Context, req logs.Request) *exec.Cmd {
 // the loop is based on the Decoder example in the docs
 // https://golang.org/pkg/encoding/json/#Decoder.Decode
 func streamLogs(ctx context.Context, cmd *exec.Cmd, out io.ReadCloser, msgs chan logs.Message) {
-	// without this sleep the channel seems to get stuck. This results in either no log messages
-	// being read by the Handler _or_ the messages are read but only flushed when the request
-	// timesout
-	time.Sleep(time.Millisecond)
 	log.Println("starting journal stream using ", cmd.String())
 
 	// will ensure `out` is closed and all related resources cleaned up


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
- Instead of sleeping to ensure the msg channel is populated, use an
  unbuffered channel. This seems to work just as well in all the manual
  tests cases

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [ ] I have raised an issue to propose this change **this is required**

This is motivated by this comment on #60 
 https://github.com/openfaas/faasd/pull/60/files/f0d512d94eb86767b5a1c853fb0a2d8eb212ad31..e50559be6ed4168d1563293391c65a482aa8a1d0#diff-c578907fddb76fcd6368480b0ffa4993

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
This was manually tested using a multipass vm

```sh
ubuntu@primary:~$ sudo pkill faasd -9 -e
faasd killed (pid 2401)
faasd killed (pid 2403)
faasd killed (pid 3132)
faasd killed (pid 3288)
ubuntu@primary:~$ sudo cp /home/ubuntu/Home/Code/go/src/github.com/openfaas/faasd/bin/faasd /usr/local/bin/faasd
ubuntu@primary:~$
ubuntu@primary:~$ faas-cli rm nodeinfo && faas-cli rm figlet
Deleting: nodeinfo.
Error removing existing function: Delete http://127.0.0.1:8080/system/functions: dial tcp 127.0.0.1:8080: connect: connection refused, gateway=http://127.0.0.1:8080, functionName=nodeinfo
Deleting: figlet.
Error removing existing function: Delete http://127.0.0.1:8080/system/functions: dial tcp 127.0.0.1:8080: connect: connection refused, gateway=http://127.0.0.1:8080, functionName=figlet
ubuntu@primary:~$ faas-cli rm nodeinfo && faas-cli rm figlet
Deleting: nodeinfo.
Removing old function.
Deleting: figlet.
Removing old function.
ubuntu@primary:~$ faas-cli store deploy figlet --env write_timeout=1s --env read_timeout=1s --label testing=true
WARNING! Communication is not secure, please consider using HTTPS. Letsencrypt.org offers free SSL/TLS certificates.

Deployed. 200 OK.
URL: http://127.0.0.1:8080/function/figlet

ubuntu@primary:~$ uname | /usr/local/bin/faas-cli invoke figlet
 _     _
| |   (_)_ __  _   ___  __
| |   | | '_ \| | | \ \/ /
| |___| | | | | |_| |>  <
|_____|_|_| |_|\__,_/_/\_\

ubuntu@primary:~$ faas-cli logs figlet --follow=false
WARNING! Communication is not secure, please consider using HTTPS. Letsencrypt.org offers free SSL/TLS certificates.
2020-03-07T09:28:17Z 2020/03/07 09:28:17 Version: 0.13.0	SHA: fa93655d90d1518b04e7cfca7d7548d7d133a34e
2020-03-07T09:28:17Z 2020/03/07 09:28:17 Read/write timeout: 1s, 1s. Port: 8080
2020-03-07T09:28:17Z 2020/03/07 09:28:17 Writing lock-file to: /tmp/.lock
2020-03-07T09:28:17Z 2020/03/07 09:28:17 Metrics server. Port: 8081
2020-03-07T09:28:22Z 2020/03/07 09:28:22 Forking fprocess.
2020-03-07T09:28:22Z 2020/03/07 09:28:22 Wrote 162 Bytes - Duration: 0.001738 seconds
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Commits:

- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [ ] My commit message has a body and describe how this was tested and why it is required.
- [x] I have signed-off my commits with `git commit -s` for the Developer Certificate of Origin (DCO)

Code:

- [x] My code follows the code style of this project.
- [ ] I have added tests to cover my changes.

Docs:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
