### PR TITLE
Allow faasd-provider to stop function tasks

### DIFF
--- a/cmd/up.go
+++ b/cmd/up.go
@@ -91,7 +91,7 @@ func runUp(_ *cobra.Command, _ []string) error {
 		log.Printf("Signal received.. shutting down server in %s\n", shutdownTimeout.String())
 		err := supervisor.Remove(services)
 		if err != nil {
-			fmt.Println(err)
+			fmt.Printf("Error removing services: %s\n", err)
 		}
 
 		// Close proxy

--- a/pkg/provider/handlers/delete.go
+++ b/pkg/provider/handlers/delete.go
@@ -54,7 +54,7 @@ func MakeDeleteHandler(client *containerd.Client, cni gocni.CNI) func(w http.Res
 		ctx := namespaces.WithNamespace(context.Background(), faasd.FunctionNamespace)
 
 		// TODO: this needs to still happen if the task is paused
-		if function.replicas != 0 {
+		if function.Replicas != 0 {
 			err = cninetwork.DeleteCNINetwork(ctx, cni, client, name)
 			if err != nil {
 				log.Printf("[Delete] error removing CNI network for %s, %s\n", name, err)

--- a/pkg/provider/handlers/functions.go
+++ b/pkg/provider/handlers/functions.go
@@ -13,13 +13,13 @@ import (
 )
 
 type Function struct {
-	name      string
-	namespace string
-	image     string
-	pid       uint32
-	replicas  int
+	Name      string
+	Namespace string
+	Image     string
+	Pid       uint32
+	Replicas  int
 	IP        string
-	labels    map[string]string
+	Labels    map[string]string
 }
 
 // ListFunctions returns a map of all functions with running tasks on namespace
@@ -54,10 +54,10 @@ func GetFunction(client *containerd.Client, name string) (Function, error) {
 		}
 
 		f := Function{
-			name:      containerName,
-			namespace: faasd.FunctionNamespace,
-			image:     image.Name(),
-			labels:    labels,
+			Name:      containerName,
+			Namespace: faasd.FunctionNamespace,
+			Image:     image.Name(),
+			Labels:    labels,
 		}
 
 		replicas := 0
@@ -70,7 +70,7 @@ func GetFunction(client *containerd.Client, name string) (Function, error) {
 			}
 			if svc.Status == "running" {
 				replicas = 1
-				f.pid = task.Pid()
+				f.Pid = task.Pid()
 
 				// Get container IP address
 				ip, err := cninetwork.GetIPfromPID(int(task.Pid()))
@@ -83,7 +83,7 @@ func GetFunction(client *containerd.Client, name string) (Function, error) {
 			replicas = 0
 		}
 
-		f.replicas = replicas
+		f.Replicas = replicas
 		return f, nil
 
 	}

--- a/pkg/provider/handlers/read.go
+++ b/pkg/provider/handlers/read.go
@@ -22,11 +22,11 @@ func MakeReadHandler(client *containerd.Client) func(w http.ResponseWriter, r *h
 		}
 		for _, function := range funcs {
 			res = append(res, types.FunctionStatus{
-				Name:      function.name,
-				Image:     function.image,
-				Replicas:  uint64(function.replicas),
-				Namespace: function.namespace,
-				Labels:    &function.labels,
+				Name:      function.Name,
+				Image:     function.Image,
+				Replicas:  uint64(function.Replicas),
+				Namespace: function.Namespace,
+				Labels:    &function.Labels,
 			})
 		}
 

--- a/pkg/provider/handlers/replicas.go
+++ b/pkg/provider/handlers/replicas.go
@@ -18,10 +18,10 @@ func MakeReplicaReaderHandler(client *containerd.Client) func(w http.ResponseWri
 		if f, err := GetFunction(client, functionName); err == nil {
 			found := types.FunctionStatus{
 				Name:              functionName,
-				AvailableReplicas: uint64(f.replicas),
-				Replicas:          uint64(f.replicas),
-				Namespace:         f.namespace,
-				Labels:            &f.labels,
+				AvailableReplicas: uint64(f.Replicas),
+				Replicas:          uint64(f.Replicas),
+				Namespace:         f.Namespace,
+				Labels:            &f.Labels,
 			}
 
 			functionBytes, _ := json.Marshal(found)

--- a/pkg/provider/handlers/scale.go
+++ b/pkg/provider/handlers/scale.go
@@ -39,65 +39,67 @@ func MakeReplicaUpdateHandler(client *containerd.Client, cni gocni.CNI) func(w h
 			return
 		}
 
-		name := req.ServiceName
-
-		if _, err := GetFunction(client, name); err != nil {
-			msg := fmt.Sprintf("service %s not found", name)
-			log.Printf("[Scale] %s\n", msg)
-			http.Error(w, msg, http.StatusNotFound)
-			return
+		status, err := ScaleFunction(client, cni, req.ServiceName, req.Replicas)
+		if status != http.StatusOK {
+			http.Error(w, err.Error(), status)
 		}
+		return
+	}
+}
 
-		ctx := namespaces.WithNamespace(context.Background(), faasd.FunctionNamespace)
-
-		ctr, ctrErr := client.LoadContainer(ctx, name)
-		if ctrErr != nil {
-			msg := fmt.Sprintf("cannot load service %s, error: %s", name, ctrErr)
-			log.Printf("[Scale] %s\n", msg)
-			http.Error(w, msg, http.StatusNotFound)
-			return
-		}
-
-		taskExists := true
-		task, taskErr := ctr.Task(ctx, nil)
-		if taskErr != nil {
-			msg := fmt.Sprintf("cannot load task for service %s, error: %s", name, taskErr)
-			log.Printf("[Scale] %s\n", msg)
-			taskExists = false
-		}
-
-		if req.Replicas > 0 {
-			if taskExists {
-				if status, statusErr := task.Status(ctx); statusErr == nil {
-					if status.Status == containerd.Paused {
-						if resumeErr := task.Resume(ctx); resumeErr != nil {
-							log.Printf("[Scale] error resuming task %s, error: %s\n", name, resumeErr)
-							http.Error(w, resumeErr.Error(), http.StatusBadRequest)
-						}
-					}
-				}
-			} else {
-				deployErr := createTask(ctx, client, ctr, cni)
-				if deployErr != nil {
-					log.Printf("[Scale] error deploying %s, error: %s\n", name, deployErr)
-					http.Error(w, deployErr.Error(), http.StatusBadRequest)
-					return
-				}
-				return
-			}
-		} else {
-			if taskExists {
-				if status, statusErr := task.Status(ctx); statusErr == nil {
-					if status.Status == containerd.Running {
-						if pauseErr := task.Pause(ctx); pauseErr != nil {
-							log.Printf("[Scale] error pausing task %s, error: %s\n", name, pauseErr)
-							http.Error(w, pauseErr.Error(), http.StatusBadRequest)
-						}
-					}
-				}
-			}
-		}
-
+func ScaleFunction(client *containerd.Client, cni gocni.CNI, name string, replicas uint64) (int, error) {
+	if _, err := GetFunction(client, name); err != nil {
+		msg := fmt.Errorf("service %s not found", name)
+		log.Printf("[Scale] %s\n", msg)
+		return http.StatusNotFound, msg
 	}
 
+	ctx := namespaces.WithNamespace(context.Background(), faasd.FunctionNamespace)
+
+	ctr, ctrErr := client.LoadContainer(ctx, name)
+	if ctrErr != nil {
+		msg := fmt.Errorf("cannot load service %s, error: %s", name, ctrErr)
+		log.Printf("[Scale] %s\n", msg)
+		return http.StatusNotFound, msg
+	}
+
+	taskExists := true
+	task, taskErr := ctr.Task(ctx, nil)
+	if taskErr != nil {
+		msg := fmt.Errorf("cannot load task for service %s, error: %s", name, taskErr)
+		log.Printf("[Scale] %s\n", msg)
+		taskExists = false
+	}
+
+	if replicas > 0 {
+		if taskExists {
+			if status, statusErr := task.Status(ctx); statusErr == nil {
+				if status.Status == containerd.Paused {
+					if resumeErr := task.Resume(ctx); resumeErr != nil {
+						log.Printf("[Scale] error resuming task %s, error: %s\n", name, resumeErr)
+						return http.StatusBadRequest, resumeErr
+					}
+				}
+			}
+		} else {
+			deployErr := createTask(ctx, client, ctr, cni)
+			if deployErr != nil {
+				log.Printf("[Scale] error deploying %s, error: %s\n", name, deployErr)
+				return http.StatusBadRequest, deployErr
+			}
+			return http.StatusOK, nil
+		}
+	} else {
+		if taskExists {
+			if status, statusErr := task.Status(ctx); statusErr == nil {
+				if status.Status == containerd.Running {
+					if pauseErr := task.Pause(ctx); pauseErr != nil {
+						log.Printf("[Scale] error pausing task %s, error: %s\n", name, pauseErr)
+						return http.StatusBadRequest, pauseErr
+					}
+				}
+			}
+		}
+	}
+	return http.StatusOK, nil
 }

--- a/pkg/provider/handlers/update.go
+++ b/pkg/provider/handlers/update.go
@@ -56,7 +56,7 @@ func MakeUpdateHandler(client *containerd.Client, cni gocni.CNI, secretMountPath
 		}
 
 		ctx := namespaces.WithNamespace(context.Background(), faasd.FunctionNamespace)
-		if function.replicas != 0 {
+		if function.Replicas != 0 {
 			err = cninetwork.DeleteCNINetwork(ctx, cni, client, name)
 			if err != nil {
 				log.Printf("[Update] error removing CNI network for %s, %s\n", name, err)

--- a/pkg/supervisor.go
+++ b/pkg/supervisor.go
@@ -211,6 +211,7 @@ func (s *Supervisor) Remove(svcs []Service) error {
 	ctx := namespaces.WithNamespace(context.Background(), faasdNamespace)
 
 	for _, svc := range svcs {
+		log.Printf("Removing service %s\n", svc.Name)
 		err := cninetwork.DeleteCNINetwork(ctx, s.cni, s.client, svc.Name)
 		if err != nil {
 			log.Printf("[Delete] error removing CNI network for %s, %s\n", svc.Name, err)


### PR DESCRIPTION
## Description

faasd-provider will capture the exit signal and pause the tasks for all
function containers by using the scale function scaling them to zero.

This way the functions can be restarted with a scale-up command on first
access.

Improved logging for faasd exit to capture faasd container errors on
stop.

Signed-off-by: Carlos de Paula <me@carlosedp.com>

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change **this is required**

This addresses part of issue #64.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Stopping faasd-provider makes all function tasks change to PAUSED. Restarting the process and making an access to the function scales it back to 1.

```
❯ faas store deploy figlet
WARNING! Communication is not secure, please consider using HTTPS. Letsencrypt.org offers free SSL/TLS certificates.

Deployed. 200 OK.
URL: http://127.0.0.1:8080/function/figlet

❯ curl -d Test http://127.0.0.1:8080/function/figlet
 _____         _
|_   _|__  ___| |_
  | |/ _ \/ __| __|
  | |  __/\__ \ |_
  |_|\___||___/\__|
```

Stop process and start back:

```
❯ sc-stop faasd-provider
❯ sudo ctr -n openfaas-fn task ls
TASK      PID     STATUS
figlet    2948    PAUSED
❯ sc-start faasd-provider
❯ faas ls
Function                      	Invocations    	Replicas
figlet                        	1              	0
❯ curl -d Test http://127.0.0.1:8080/function/figlet
 _____         _
|_   _|__  ___| |_
  | |/ _ \/ __| __|
  | |  __/\__ \ |_
  |_|\___||___/\__|

❯ faas ls
Function                      	Invocations    	Replicas
figlet                        	1              	1
```

Logs:

```
Mar 09 18:19:02 debian10 faasd[2265]: 2020/03/09 18:19:02 [Deploy] request: {"service":"figlet","image":"functions/figlet:0.13.0","network":"","envProcess":"figlet","envVars":{},"constraints":[],"secrets":[],"labels":{},"annotations":{},"limits":null,"requests":null,"readOnlyRootFilesystem":false}
Mar 09 18:19:04 debian10 faasd[2265]: 2020/03/09 18:19:04 Deploy docker.io/functions/figlet:0.13.0 size: 5658006
Mar 09 18:19:04 debian10 faasd[2265]: 2020/03/09 18:19:04 Container ID: figlet        Task ID figlet:        Task PID: 2948
Mar 09 18:19:04 debian10 faasd[2265]: 2020/03/09 18:19:04 figlet has IP: 10.62.0.209.
Mar 09 18:19:12 debian10 faasd[2265]: 2020/03/09 18:19:12 Resolve: "figlet"
Mar 09 18:19:12 debian10 faasd[2265]: 2020/03/09 18:19:12 figlet took 0.013644 seconds
Mar 09 18:19:17 debian10 systemd[1]: Stopping faasd-provider...
-- Subject: A stop job for unit faasd-provider.service has begun execution
-- Defined-By: systemd
-- Support: https://www.debian.org/support
--
-- A stop job for unit faasd-provider.service has begun execution.
--
-- The job identifier is 774.
Mar 09 18:19:17 debian10 faasd[2265]: 2020/03/09 18:19:17 Signal received.. shutting down provider and functions.
Mar 09 18:19:17 debian10 faasd[2265]: 2020/03/09 18:19:17 Stopping function figlet.
Mar 09 18:19:17 debian10 faasd[2265]: Finished scaling functions to 0.
Mar 09 18:19:17 debian10 systemd[1]: faasd-provider.service: Succeeded.
-- Subject: Unit succeeded
-- Defined-By: systemd
-- Support: https://www.debian.org/support
--
-- The unit faasd-provider.service has successfully entered the 'dead' state.
Mar 09 18:19:17 debian10 systemd[1]: Stopped faasd-provider.
-- Subject: A stop job for unit faasd-provider.service has finished
-- Defined-By: systemd
-- Support: https://www.debian.org/support
--
-- A stop job for unit faasd-provider.service has finished.
--
-- The job identifier is 774 and the job result is done.
Mar 09 18:19:50 debian10 systemd[1]: Started faasd-provider.
-- Subject: A start job for unit faasd-provider.service has finished successfully
-- Defined-By: systemd
-- Support: https://www.debian.org/support
--
-- A start job for unit faasd-provider.service has finished successfully.
--
-- The job identifier is 775.
Mar 09 18:19:50 debian10 faasd[3091]: 2020/03/09 18:19:50 faasd-provider starting..        Service Timeout: 1m0s
Mar 09 18:19:50 debian10 faasd[3091]: 2020/03/09 18:19:50 Writing network config...
Mar 09 18:19:50 debian10 faasd[3091]: 2020/03/09 18:19:50 Listening on TCP port: 8081
Mar 09 18:19:50 debian10 faasd[3091]: 2020/03/09 18:19:50 faasd-provider: waiting for SIGTERM or SIGINT to stop.


Mar 09 18:20:15 debian10 faasd[3091]: 2020/03/09 18:20:15 [Scale] request: {"serviceName":"figlet","serviceNamespace":"","replicas":1}
Mar 09 18:20:15 debian10 faasd[3091]: 2020/03/09 18:20:15 Resolve: "figlet"
Mar 09 18:20:15 debian10 faasd[3091]: 2020/03/09 18:20:15 figlet took 0.002255 seconds
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Commits:

- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] My commit message has a body and describe how this was tested and why it is required.
- [x] I have signed-off my commits with `git commit -s` for the Developer Certificate of Origin (DCO)

Code:

- [x] My code follows the code style of this project.
- [ ] I have added tests to cover my changes.

Docs:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
