### PR TITLE
Fix vulnerability in authenticated secrets API

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ addons:
       - runc
 
 script:
+- make test
 - make dist
 - make prepare-test
 - make test-e2e

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,10 @@ all: local
 local:
 	CGO_ENABLED=0 GOOS=linux go build -o bin/faasd
 
+.PHONY: test
+test:
+	CGO_ENABLED=0 GOOS=linux go test -ldflags $(LDFLAGS) ./...
+
 .PHONY: dist
 dist:
 	CGO_ENABLED=0 GOOS=linux go build -ldflags $(LDFLAGS) -a -installsuffix cgo -o bin/faasd

--- a/pkg/logs/requestor_test.go
+++ b/pkg/logs/requestor_test.go
@@ -29,19 +29,19 @@ func Test_parseEntry(t *testing.T) {
 	}
 
 	if entry.Name != expectedEntry.Name {
-		t.Fatalf("expected Name %s, got %s", expectedEntry.Name, entry.Name)
+		t.Fatalf("want Name: %q, got %q", expectedEntry.Name, entry.Name)
 	}
 
 	if entry.Namespace != expectedEntry.Namespace {
-		t.Fatalf("expected Namespace %s, got %s", expectedEntry.Namespace, entry.Namespace)
+		t.Fatalf("want Namespace: %q, got %q", expectedEntry.Namespace, entry.Namespace)
 	}
 
 	if entry.Timestamp != expectedEntry.Timestamp {
-		t.Fatalf("expected Timestamp %s, got %s", expectedEntry.Timestamp, entry.Timestamp)
+		t.Fatalf("want Timestamp: %q, got %q", expectedEntry.Timestamp, entry.Timestamp)
 	}
 
 	if entry.Text != expectedEntry.Text {
-		t.Fatalf("expected Text %s, got %s", expectedEntry.Text, entry.Text)
+		t.Fatalf("want Text: %q, got %q", expectedEntry.Text, entry.Text)
 	}
 }
 

--- a/pkg/logs/requestor_test.go
+++ b/pkg/logs/requestor_test.go
@@ -62,12 +62,12 @@ func Test_buildCmd(t *testing.T) {
 	)
 
 	cmd := buildCmd(ctx, req).String()
-
-	if !strings.Contains(cmd, "journalctl") {
-		t.Fatalf("expected journalctl cmd, got cmd %s", cmd)
+	wantCmd := "journalctl"
+	if !strings.Contains(cmd, wantCmd) {
+		t.Fatalf("cmd want: %q, got: %q", wantCmd, cmd)
 	}
 
 	if !strings.HasSuffix(cmd, expectedArgs) {
-		t.Fatalf("expected arg %s,\ngot cmd %s", expectedArgs, cmd)
+		t.Fatalf("arg want: %q\ngot: %q", expectedArgs, cmd)
 	}
 }

--- a/pkg/provider/handlers/secret_test.go
+++ b/pkg/provider/handlers/secret_test.go
@@ -1,0 +1,63 @@
+package handlers
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/openfaas/faas-provider/types"
+)
+
+func Test_parseSecretValidName(t *testing.T) {
+
+	s := types.Secret{Name: "authorized_keys"}
+	body, _ := json.Marshal(s)
+	reader := bytes.NewReader(body)
+	r := httptest.NewRequest(http.MethodPost, "/", reader)
+	_, err := parseSecret(r)
+
+	if err != nil {
+		t.Fatalf("secret name is valid with no traversal characters")
+	}
+}
+
+func Test_parseSecretValidNameWithDot(t *testing.T) {
+
+	s := types.Secret{Name: "authorized.keys"}
+	body, _ := json.Marshal(s)
+	reader := bytes.NewReader(body)
+	r := httptest.NewRequest(http.MethodPost, "/", reader)
+	_, err := parseSecret(r)
+
+	if err != nil {
+		t.Fatalf("secret name is valid with no traversal characters")
+	}
+}
+
+func Test_parseSecretWithTraversalWithSlash(t *testing.T) {
+
+	s := types.Secret{Name: "/root/.ssh/authorized_keys"}
+	body, _ := json.Marshal(s)
+	reader := bytes.NewReader(body)
+	r := httptest.NewRequest(http.MethodPost, "/", reader)
+	_, err := parseSecret(r)
+
+	if err == nil {
+		t.Fatalf("secret name should fail due to path traversal")
+	}
+}
+
+func Test_parseSecretWithTraversalWithDoubleDot(t *testing.T) {
+
+	s := types.Secret{Name: ".."}
+	body, _ := json.Marshal(s)
+	reader := bytes.NewReader(body)
+	r := httptest.NewRequest(http.MethodPost, "/", reader)
+	_, err := parseSecret(r)
+
+	if err == nil {
+		t.Fatalf("secret name should fail due to path traversal")
+	}
+}


### PR DESCRIPTION
This patch fixes a vulnerability in the secrets API, however
it is important to stress that the user must be authenticated
as the admin user on the REST API before they can attempt this.

Reported by Appsecco via email. @lucasroesler, Appsecco and
myself believe this to be of low severity.

The fix prevents directory traversal characters from being
used in secret names. If a secret name such as:
../../root/.ssh/authorized_keys were to be used, an attacker
could remove the value and write their own.

Signed-off-by: Alex Ellis (OpenFaaS Ltd) <alexellis2@gmail.com>
