### PR TITLE
Update OpenFaaS core components for faasd

### DIFF
--- a/cmd/up.go
+++ b/cmd/up.go
@@ -175,7 +175,7 @@ func makeServiceDefinitions(archSuffix string) []pkg.Service {
 	return []pkg.Service{
 		{
 			Name:  "basic-auth-plugin",
-			Image: "docker.io/openfaas/basic-auth-plugin:0.18.10" + archSuffix,
+			Image: "docker.io/openfaas/basic-auth-plugin:0.18.17" + archSuffix,
 			Env: []string{
 				"port=8080",
 				"secret_mount_path=" + containerSecretMountDir,
@@ -230,7 +230,7 @@ func makeServiceDefinitions(archSuffix string) []pkg.Service {
 				"secret_mount_path=" + containerSecretMountDir,
 				"scale_from_zero=true",
 			},
-			Image: "docker.io/openfaas/gateway:0.18.8" + archSuffix,
+			Image: "docker.io/openfaas/gateway:0.18.17" + archSuffix,
 			Mounts: []pkg.Mount{
 				{
 					Src:  path.Join(path.Join(wd, "secrets"), "basic-auth-password"),
@@ -256,7 +256,7 @@ func makeServiceDefinitions(archSuffix string) []pkg.Service {
 				"basic_auth=true",
 				"secret_mount_path=" + containerSecretMountDir,
 			},
-			Image: "docker.io/openfaas/queue-worker:0.9.0",
+			Image: "docker.io/openfaas/queue-worker:0.11.2",
 			Mounts: []pkg.Mount{
 				{
 					Src:  path.Join(path.Join(wd, "secrets"), "basic-auth-password"),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Update OpenFaas Core components

basic-auth-plugin: 0.18.10 -> 0.18.17
gateway:                 0.18.8   -> 0.18.17
queue-worker:        0.9.0    -> 0.11.2

There are no new configuration items were introduced in the updated version,so I did not update the configuration item

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change **this is required**

 Issue raised by Alex   #73 


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I deployed a new version of the fassd in IaaS(Azure) and tested it

Log before update
```
-- Logs begin at Wed 2020-05-27 14:31:13 UTC, end at Wed 2020-05-27 15:15:31 UTC. --
May 27 15:10:47 openfaas-new systemd[1]: Started faasd.
May 27 15:10:47 openfaas-new faasd[14051]: 2020/05/27 15:10:47 File exists: "/var/lib/faasd/secrets/basic-auth-password"
May 27 15:10:47 openfaas-new faasd[14051]: 2020/05/27 15:10:47 File exists: "/var/lib/faasd/secrets/basic-auth-user"
May 27 15:10:47 openfaas-new faasd[14051]: 2020/05/27 15:10:47 Writing network config...
May 27 15:10:47 openfaas-new faasd[14051]: 2020/05/27 15:10:47 Supervisor created in: 1.124581ms
May 27 15:10:47 openfaas-new faasd[14051]: Preparing: basic-auth-plugin with image: docker.io/openfaas/basic-auth-plugin:0.18.10
May 27 15:11:02 openfaas-new faasd[14051]: Prepare done for: docker.io/openfaas/basic-auth-plugin:0.18.10, 7171180 bytes
May 27 15:11:02 openfaas-new faasd[14051]: Preparing: nats with image: docker.io/library/nats-streaming:0.11.2
May 27 15:11:04 openfaas-new faasd[14051]: Prepare done for: docker.io/library/nats-streaming:0.11.2, 4647125 bytes
May 27 15:11:04 openfaas-new faasd[14051]: Preparing: prometheus with image: docker.io/prom/prometheus:v2.14.0
May 27 15:11:12 openfaas-new faasd[14051]: Prepare done for: docker.io/prom/prometheus:v2.14.0, 53527559 bytes
May 27 15:11:12 openfaas-new faasd[14051]: Preparing: gateway with image: docker.io/openfaas/gateway:0.18.8
May 27 15:11:18 openfaas-new faasd[14051]: Prepare done for: docker.io/openfaas/gateway:0.18.8, 11117867 bytes
May 27 15:11:18 openfaas-new faasd[14051]: Preparing: queue-worker with image: docker.io/openfaas/queue-worker:0.9.0
May 27 15:11:21 openfaas-new faasd[14051]: Prepare done for: docker.io/openfaas/queue-worker:0.9.0, 4293659 bytes
May 27 15:11:21 openfaas-new faasd[14051]: Reconciling: basic-auth-plugin
May 27 15:11:31 openfaas-new faasd[14051]: 2020/05/27 15:11:31 Created container basic-auth-plugin
May 27 15:11:31 openfaas-new faasd[14051]: 2020/05/27 15:11:31 basic-auth-plugin has IP: 10.62.0.2
May 27 15:11:31 openfaas-new faasd[14051]: 2020/05/27 15:11:31 Task: basic-auth-plugin        Container: basic-auth-plugin
May 27 15:11:31 openfaas-new faasd[14051]: 2020/05/27 15:11:31 Listening on: 8080
May 27 15:11:31 openfaas-new faasd[14051]: Reconciling: nats
May 27 15:11:32 openfaas-new faasd[14051]: 2020/05/27 15:11:32 Created container nats
May 27 15:11:32 openfaas-new faasd[14051]: 2020/05/27 15:11:32 nats has IP: 10.62.0.3
May 27 15:11:32 openfaas-new faasd[14051]: 2020/05/27 15:11:32 Task: nats        Container: nats
May 27 15:11:32 openfaas-new faasd[14051]: Reconciling: prometheus
May 27 15:11:32 openfaas-new faasd[14051]: [1] 2020/05/27 15:11:32.129216 [INF] STREAM: Starting nats-streaming-server[faas-cluster] version 0.11.2
May 27 15:11:32 openfaas-new faasd[14051]: [1] 2020/05/27 15:11:32.129248 [INF] STREAM: ServerID: QH74Q5z1tIy8MzB2TY0sUV
May 27 15:11:32 openfaas-new faasd[14051]: [1] 2020/05/27 15:11:32.129252 [INF] STREAM: Go version: go1.11.1
May 27 15:11:32 openfaas-new faasd[14051]: [1] 2020/05/27 15:11:32.130255 [INF] Starting nats-server version 1.3.0
May 27 15:11:32 openfaas-new faasd[14051]: [1] 2020/05/27 15:11:32.130260 [INF] Git commit [not set]
May 27 15:11:32 openfaas-new faasd[14051]: [1] 2020/05/27 15:11:32.130508 [INF] Starting http monitor on 0.0.0.0:8222
May 27 15:11:32 openfaas-new faasd[14051]: [1] 2020/05/27 15:11:32.130540 [INF] Listening for client connections on 0.0.0.0:4222
May 27 15:11:32 openfaas-new faasd[14051]: [1] 2020/05/27 15:11:32.130543 [INF] Server is ready
May 27 15:11:32 openfaas-new faasd[14051]: [1] 2020/05/27 15:11:32.156893 [INF] STREAM: Recovering the state...
May 27 15:11:32 openfaas-new faasd[14051]: [1] 2020/05/27 15:11:32.156904 [INF] STREAM: No recovered state
May 27 15:11:32 openfaas-new faasd[14051]: 2020/05/27 15:11:32 Created container prometheus
May 27 15:11:32 openfaas-new faasd[14051]: 2020/05/27 15:11:32 prometheus has IP: 10.62.0.4
May 27 15:11:32 openfaas-new faasd[14051]: 2020/05/27 15:11:32 Task: prometheus        Container: prometheus
May 27 15:11:32 openfaas-new faasd[14051]: Reconciling: gateway
May 27 15:11:32 openfaas-new faasd[14051]: level=info ts=2020-05-27T15:11:32.372Z caller=main.go:296 msg="no time or size retention was set so using the default time retention" duration=15d
May 27 15:11:32 openfaas-new faasd[14051]: level=info ts=2020-05-27T15:11:32.372Z caller=main.go:332 msg="Starting Prometheus" version="(version=2.14.0, branch=HEAD, revision=edeb7a44cbf745f1d8be4ea6f215e79e651bfe19)"
May 27 15:11:32 openfaas-new faasd[14051]: level=info ts=2020-05-27T15:11:32.373Z caller=main.go:333 build_context="(go=go1.13.4, user=root@df2327081015, date=20191111-14:27:12)"
May 27 15:11:32 openfaas-new faasd[14051]: level=info ts=2020-05-27T15:11:32.373Z caller=main.go:334 host_details="(Linux 5.3.0-1020-azure #21~18.04.1-Ubuntu SMP Wed Apr 15 09:35:56 UTC 2020 x86_64 openfaas-new (none))"
May 27 15:11:32 openfaas-new faasd[14051]: level=info ts=2020-05-27T15:11:32.373Z caller=main.go:335 fd_limits="(soft=1024, hard=1024)"
May 27 15:11:32 openfaas-new faasd[14051]: level=info ts=2020-05-27T15:11:32.373Z caller=main.go:336 vm_limits="(soft=unlimited, hard=unlimited)"
May 27 15:11:32 openfaas-new faasd[14051]: level=info ts=2020-05-27T15:11:32.375Z caller=main.go:657 msg="Starting TSDB ..."
May 27 15:11:32 openfaas-new faasd[14051]: level=info ts=2020-05-27T15:11:32.378Z caller=web.go:496 component=web msg="Start listening for connections" address=0.0.0.0:9090
May 27 15:11:32 openfaas-new faasd[14051]: level=info ts=2020-05-27T15:11:32.384Z caller=head.go:535 component=tsdb msg="replaying WAL, this may take awhile"
May 27 15:11:32 openfaas-new faasd[14051]: level=info ts=2020-05-27T15:11:32.384Z caller=head.go:583 component=tsdb msg="WAL segment loaded" segment=0 maxSegment=0
May 27 15:11:32 openfaas-new faasd[14051]: level=info ts=2020-05-27T15:11:32.385Z caller=main.go:672 fs_type=794c7630
May 27 15:11:32 openfaas-new faasd[14051]: level=info ts=2020-05-27T15:11:32.385Z caller=main.go:673 msg="TSDB started"
May 27 15:11:32 openfaas-new faasd[14051]: level=info ts=2020-05-27T15:11:32.385Z caller=main.go:743 msg="Loading configuration file" filename=/etc/prometheus/prometheus.yml
May 27 15:11:32 openfaas-new faasd[14051]: level=info ts=2020-05-27T15:11:32.390Z caller=main.go:771 msg="Completed loading of configuration file" filename=/etc/prometheus/prometheus.yml
May 27 15:11:32 openfaas-new faasd[14051]: level=info ts=2020-05-27T15:11:32.390Z caller=main.go:626 msg="Server is ready to receive web requests."
May 27 15:11:32 openfaas-new faasd[14051]: [1] 2020/05/27 15:11:32.407290 [INF] STREAM: Message store is MEMORY
May 27 15:11:32 openfaas-new faasd[14051]: [1] 2020/05/27 15:11:32.407337 [INF] STREAM: ---------- Store Limits ----------
May 27 15:11:32 openfaas-new faasd[14051]: [1] 2020/05/27 15:11:32.407341 [INF] STREAM: Channels:                  100 *
May 27 15:11:32 openfaas-new faasd[14051]: [1] 2020/05/27 15:11:32.407343 [INF] STREAM: --------- Channels Limits --------
May 27 15:11:32 openfaas-new faasd[14051]: [1] 2020/05/27 15:11:32.407345 [INF] STREAM:   Subscriptions:          1000 *
May 27 15:11:32 openfaas-new faasd[14051]: [1] 2020/05/27 15:11:32.407348 [INF] STREAM:   Messages     :       1000000 *
May 27 15:11:32 openfaas-new faasd[14051]: [1] 2020/05/27 15:11:32.407350 [INF] STREAM:   Bytes        :     976.56 MB *
May 27 15:11:32 openfaas-new faasd[14051]: [1] 2020/05/27 15:11:32.407352 [INF] STREAM:   Age          :     unlimited *
May 27 15:11:32 openfaas-new faasd[14051]: [1] 2020/05/27 15:11:32.407354 [INF] STREAM:   Inactivity   :     unlimited *
May 27 15:11:32 openfaas-new faasd[14051]: [1] 2020/05/27 15:11:32.407357 [INF] STREAM: ----------------------------------
May 27 15:11:32 openfaas-new faasd[14051]: 2020/05/27 15:11:32 Created container gateway
May 27 15:11:32 openfaas-new faasd[14051]: 2020/05/27 15:11:32 gateway has IP: 10.62.0.5
May 27 15:11:32 openfaas-new faasd[14051]: 2020/05/27 15:11:32 Task: gateway        Container: gateway
May 27 15:11:32 openfaas-new faasd[14051]: Reconciling: queue-worker
May 27 15:11:32 openfaas-new faasd[14051]: 2020/05/27 15:11:32 HTTP Read Timeout: 1m0s
May 27 15:11:32 openfaas-new faasd[14051]: 2020/05/27 15:11:32 HTTP Write Timeout: 1m0s
May 27 15:11:32 openfaas-new faasd[14051]: 2020/05/27 15:11:32 Binding to external function provider: http://faasd-provider:8081/
May 27 15:11:32 openfaas-new faasd[14051]: 2020/05/27 15:11:32 Async enabled: Using NATS Streaming.
May 27 15:11:32 openfaas-new faasd[14051]: 2020/05/27 15:11:32 Opening connection to nats://nats:4222
May 27 15:11:32 openfaas-new faasd[14051]: 2020/05/27 15:11:32 Connect: nats://nats:4222
May 27 15:11:32 openfaas-new faasd[14051]: 2020/05/27 15:11:32 Created container queue-worker
May 27 15:11:32 openfaas-new faasd[14051]: 2020/05/27 15:11:32 queue-worker has IP: 10.62.0.6
May 27 15:11:32 openfaas-new faasd[14051]: 2020/05/27 15:11:32 Task: queue-worker        Container: queue-worker
May 27 15:11:32 openfaas-new faasd[14051]: 2020/05/27 15:11:32 Supervisor init done in: 45.581913146s
May 27 15:11:32 openfaas-new faasd[14051]: 2020/05/27 15:11:32 faasd: waiting for SIGTERM or SIGINT
May 27 15:11:32 openfaas-new faasd[14051]: Loading basic authentication credentials
May 27 15:11:32 openfaas-new faasd[14051]: Connect: nats://nats:4222
May 27 15:11:32 openfaas-new faasd[14051]: [1] 2020/05/27 15:11:32.802400 [INF] STREAM: Channel "faas-request" has been created
May 27 15:11:32 openfaas-new faasd[14051]: Subscribing to: faas-request at nats://nats:4222
May 27 15:11:32 openfaas-new faasd[14051]: Wait for  5m5s
May 27 15:11:32 openfaas-new faasd[14051]: Listening on [faas-request], clientID=[faas-worker-openfaas-new], qgroup=[faas] durable=[]
May 27 15:11:35 openfaas-new faasd[14051]: 2020/05/27 15:11:35 [up] Sending 10.62.0.5 to proxy
May 27 15:11:35 openfaas-new faasd[14051]: 2020/05/27 15:11:35 Starting faasd proxy on 8080
May 27 15:11:35 openfaas-new faasd[14051]: Gateway: 10.62.0.5:8080
May 27 15:11:35 openfaas-new faasd[14051]: 2020/05/27 15:11:35 [proxy] Wait for done
May 27 15:11:35 openfaas-new faasd[14051]: 2020/05/27 15:11:35 [proxy] Begin listen on 8080
May 27 15:14:06 openfaas-new faasd[14051]: [faasd] proxy: http://10.62.0.5:8080/
May 27 15:14:06 openfaas-new faasd[14051]: [faasd] proxy: http://10.62.0.5:8080/ui/
May 27 15:14:06 openfaas-new faasd[14051]: 2020/05/27 15:14:06 Validated request 401.
May 27 15:14:29 openfaas-new faasd[14051]: [faasd] proxy: http://10.62.0.5:8080/ui/
May 27 15:14:29 openfaas-new faasd[14051]: 2020/05/27 15:14:29 Validated request 200.
May 27 15:14:30 openfaas-new faasd[14051]: [faasd] proxy: http://10.62.0.5:8080/ui/style/angular_material/1.1.0/angular-material.min.css
May 27 15:14:30 openfaas-new faasd[14051]: 2020/05/27 15:14:30 Validated request 200.


```

Log after update

```
-- Logs begin at Wed 2020-05-27 15:23:32 UTC, end at Wed 2020-05-27 15:48:49 UTC. --
May 27 15:29:37 openfaas-new2 systemd[1]: Started faasd.
May 27 15:29:37 openfaas-new2 faasd[2610]: 2020/05/27 15:29:37 File exists: "/var/lib/faasd/secrets/basic-auth-password"
May 27 15:29:37 openfaas-new2 faasd[2610]: 2020/05/27 15:29:37 File exists: "/var/lib/faasd/secrets/basic-auth-user"
May 27 15:29:37 openfaas-new2 faasd[2610]: 2020/05/27 15:29:37 Writing network config...
May 27 15:29:37 openfaas-new2 faasd[2610]: 2020/05/27 15:29:37 Supervisor created in: 906.34µs
May 27 15:29:37 openfaas-new2 faasd[2610]: Preparing: basic-auth-plugin with image: docker.io/openfaas/basic-auth-plugin:0.18.17
May 27 15:30:10 openfaas-new2 faasd[2610]: Prepare done for: docker.io/openfaas/basic-auth-plugin:0.18.17, 7308063 bytes
May 27 15:30:10 openfaas-new2 faasd[2610]: Preparing: nats with image: docker.io/library/nats-streaming:0.11.2
May 27 15:30:12 openfaas-new2 faasd[2610]: Prepare done for: docker.io/library/nats-streaming:0.11.2, 4647125 bytes
May 27 15:30:12 openfaas-new2 faasd[2610]: Preparing: prometheus with image: docker.io/prom/prometheus:v2.14.0
May 27 15:30:23 openfaas-new2 faasd[2610]: Prepare done for: docker.io/prom/prometheus:v2.14.0, 53527559 bytes
May 27 15:30:23 openfaas-new2 faasd[2610]: Preparing: gateway with image: docker.io/openfaas/gateway:0.18.17
May 27 15:30:25 openfaas-new2 faasd[2610]: Prepare done for: docker.io/openfaas/gateway:0.18.17, 11812608 bytes
May 27 15:30:25 openfaas-new2 faasd[2610]: Preparing: queue-worker with image: docker.io/openfaas/queue-worker:0.11.2
May 27 15:30:29 openfaas-new2 faasd[2610]: Prepare done for: docker.io/openfaas/queue-worker:0.11.2, 2922707 bytes
May 27 15:30:29 openfaas-new2 faasd[2610]: Reconciling: basic-auth-plugin
May 27 15:30:43 openfaas-new2 faasd[2610]: 2020/05/27 15:30:43 Created container basic-auth-plugin
May 27 15:30:44 openfaas-new2 faasd[2610]: 2020/05/27 15:30:44 basic-auth-plugin has IP: 10.62.0.2
May 27 15:30:44 openfaas-new2 faasd[2610]: 2020/05/27 15:30:44 Task: basic-auth-plugin        Container: basic-auth-plugin
May 27 15:30:44 openfaas-new2 faasd[2610]: 2020/05/27 15:30:44 Listening on: 8080
May 27 15:30:44 openfaas-new2 faasd[2610]: Reconciling: nats
May 27 15:30:44 openfaas-new2 faasd[2610]: 2020/05/27 15:30:44 Created container nats
May 27 15:30:44 openfaas-new2 faasd[2610]: 2020/05/27 15:30:44 nats has IP: 10.62.0.3
May 27 15:30:44 openfaas-new2 faasd[2610]: 2020/05/27 15:30:44 Task: nats        Container: nats
May 27 15:30:44 openfaas-new2 faasd[2610]: Reconciling: prometheus
May 27 15:30:44 openfaas-new2 faasd[2610]: [1] 2020/05/27 15:30:44.409281 [INF] STREAM: Starting nats-streaming-server[faas-cluster] version 0.11.2
May 27 15:30:44 openfaas-new2 faasd[2610]: [1] 2020/05/27 15:30:44.409313 [INF] STREAM: ServerID: 3V8rTcKkzhpLYRnCrYXenv
May 27 15:30:44 openfaas-new2 faasd[2610]: [1] 2020/05/27 15:30:44.409316 [INF] STREAM: Go version: go1.11.1
May 27 15:30:44 openfaas-new2 faasd[2610]: [1] 2020/05/27 15:30:44.410409 [INF] Starting nats-server version 1.3.0
May 27 15:30:44 openfaas-new2 faasd[2610]: [1] 2020/05/27 15:30:44.410422 [INF] Git commit [not set]
May 27 15:30:44 openfaas-new2 faasd[2610]: [1] 2020/05/27 15:30:44.410647 [INF] Starting http monitor on 0.0.0.0:8222
May 27 15:30:44 openfaas-new2 faasd[2610]: [1] 2020/05/27 15:30:44.410687 [INF] Listening for client connections on 0.0.0.0:4222
May 27 15:30:44 openfaas-new2 faasd[2610]: [1] 2020/05/27 15:30:44.410692 [INF] Server is ready
May 27 15:30:44 openfaas-new2 faasd[2610]: [1] 2020/05/27 15:30:44.436710 [INF] STREAM: Recovering the state...
May 27 15:30:44 openfaas-new2 faasd[2610]: [1] 2020/05/27 15:30:44.436725 [INF] STREAM: No recovered state
May 27 15:30:44 openfaas-new2 faasd[2610]: 2020/05/27 15:30:44 Created container prometheus
May 27 15:30:44 openfaas-new2 faasd[2610]: 2020/05/27 15:30:44 prometheus has IP: 10.62.0.4
May 27 15:30:44 openfaas-new2 faasd[2610]: 2020/05/27 15:30:44 Task: prometheus        Container: prometheus
May 27 15:30:44 openfaas-new2 faasd[2610]: Reconciling: gateway
May 27 15:30:44 openfaas-new2 faasd[2610]: [1] 2020/05/27 15:30:44.688294 [INF] STREAM: Message store is MEMORY
May 27 15:30:44 openfaas-new2 faasd[2610]: [1] 2020/05/27 15:30:44.688375 [INF] STREAM: ---------- Store Limits ----------
May 27 15:30:44 openfaas-new2 faasd[2610]: [1] 2020/05/27 15:30:44.688380 [INF] STREAM: Channels:                  100 *
May 27 15:30:44 openfaas-new2 faasd[2610]: [1] 2020/05/27 15:30:44.688382 [INF] STREAM: --------- Channels Limits --------
May 27 15:30:44 openfaas-new2 faasd[2610]: [1] 2020/05/27 15:30:44.688402 [INF] STREAM:   Subscriptions:          1000 *
May 27 15:30:44 openfaas-new2 faasd[2610]: [1] 2020/05/27 15:30:44.688405 [INF] STREAM:   Messages     :       1000000 *
May 27 15:30:44 openfaas-new2 faasd[2610]: [1] 2020/05/27 15:30:44.688407 [INF] STREAM:   Bytes        :     976.56 MB *
May 27 15:30:44 openfaas-new2 faasd[2610]: [1] 2020/05/27 15:30:44.688409 [INF] STREAM:   Age          :     unlimited *
May 27 15:30:44 openfaas-new2 faasd[2610]: [1] 2020/05/27 15:30:44.688412 [INF] STREAM:   Inactivity   :     unlimited *
May 27 15:30:44 openfaas-new2 faasd[2610]: [1] 2020/05/27 15:30:44.688414 [INF] STREAM: ----------------------------------
May 27 15:30:44 openfaas-new2 faasd[2610]: level=info ts=2020-05-27T15:30:44.705Z caller=main.go:296 msg="no time or size retention was set so using the default time retention" duration=15d
May 27 15:30:44 openfaas-new2 faasd[2610]: level=info ts=2020-05-27T15:30:44.705Z caller=main.go:332 msg="Starting Prometheus" version="(version=2.14.0, branch=HEAD, revision=edeb7a44cbf745f1d8be4ea6f215e79e651bfe19)"
May 27 15:30:44 openfaas-new2 faasd[2610]: level=info ts=2020-05-27T15:30:44.705Z caller=main.go:333 build_context="(go=go1.13.4, user=root@df2327081015, date=20191111-14:27:12)"
May 27 15:30:44 openfaas-new2 faasd[2610]: level=info ts=2020-05-27T15:30:44.705Z caller=main.go:334 host_details="(Linux 5.3.0-1020-azure #21~18.04.1-Ubuntu SMP Wed Apr 15 09:35:56 UTC 2020 x86_64 openfaas-new2 (none))"
May 27 15:30:44 openfaas-new2 faasd[2610]: level=info ts=2020-05-27T15:30:44.705Z caller=main.go:335 fd_limits="(soft=1024, hard=1024)"
May 27 15:30:44 openfaas-new2 faasd[2610]: level=info ts=2020-05-27T15:30:44.705Z caller=main.go:336 vm_limits="(soft=unlimited, hard=unlimited)"
May 27 15:30:44 openfaas-new2 faasd[2610]: level=info ts=2020-05-27T15:30:44.707Z caller=main.go:657 msg="Starting TSDB ..."
May 27 15:30:44 openfaas-new2 faasd[2610]: level=info ts=2020-05-27T15:30:44.708Z caller=web.go:496 component=web msg="Start listening for connections" address=0.0.0.0:9090
May 27 15:30:44 openfaas-new2 faasd[2610]: level=info ts=2020-05-27T15:30:44.716Z caller=head.go:535 component=tsdb msg="replaying WAL, this may take awhile"
May 27 15:30:44 openfaas-new2 faasd[2610]: level=info ts=2020-05-27T15:30:44.716Z caller=head.go:583 component=tsdb msg="WAL segment loaded" segment=0 maxSegment=0
May 27 15:30:44 openfaas-new2 faasd[2610]: level=info ts=2020-05-27T15:30:44.718Z caller=main.go:672 fs_type=794c7630
May 27 15:30:44 openfaas-new2 faasd[2610]: level=info ts=2020-05-27T15:30:44.718Z caller=main.go:673 msg="TSDB started"
May 27 15:30:44 openfaas-new2 faasd[2610]: level=info ts=2020-05-27T15:30:44.718Z caller=main.go:743 msg="Loading configuration file" filename=/etc/prometheus/prometheus.yml
May 27 15:30:44 openfaas-new2 faasd[2610]: level=info ts=2020-05-27T15:30:44.723Z caller=main.go:771 msg="Completed loading of configuration file" filename=/etc/prometheus/prometheus.yml
May 27 15:30:44 openfaas-new2 faasd[2610]: level=info ts=2020-05-27T15:30:44.723Z caller=main.go:626 msg="Server is ready to receive web requests."
May 27 15:30:44 openfaas-new2 faasd[2610]: 2020/05/27 15:30:44 Created container gateway
May 27 15:30:44 openfaas-new2 faasd[2610]: 2020/05/27 15:30:44 gateway has IP: 10.62.0.5
May 27 15:30:44 openfaas-new2 faasd[2610]: 2020/05/27 15:30:44 Task: gateway        Container: gateway
May 27 15:30:44 openfaas-new2 faasd[2610]: Reconciling: queue-worker
May 27 15:30:44 openfaas-new2 faasd[2610]: 2020/05/27 15:30:44 HTTP Read Timeout: 1m0s
May 27 15:30:44 openfaas-new2 faasd[2610]: 2020/05/27 15:30:44 HTTP Write Timeout: 1m0s
May 27 15:30:44 openfaas-new2 faasd[2610]: 2020/05/27 15:30:44 Binding to external function provider: http://faasd-provider:8081/
May 27 15:30:44 openfaas-new2 faasd[2610]: 2020/05/27 15:30:44 Async enabled: Using NATS Streaming.
May 27 15:30:44 openfaas-new2 faasd[2610]: 2020/05/27 15:30:44 Opening connection to nats://nats:4222
May 27 15:30:44 openfaas-new2 faasd[2610]: 2020/05/27 15:30:44 Connect: nats://nats:4222
May 27 15:30:44 openfaas-new2 faasd[2610]: &{0xc00000dd00}
May 27 15:30:45 openfaas-new2 faasd[2610]: 2020/05/27 15:30:45 Created container queue-worker
May 27 15:30:45 openfaas-new2 faasd[2610]: 2020/05/27 15:30:45 queue-worker has IP: 10.62.0.6
May 27 15:30:45 openfaas-new2 faasd[2610]: 2020/05/27 15:30:45 Task: queue-worker        Container: queue-worker
May 27 15:30:45 openfaas-new2 faasd[2610]: Loading basic authentication credentials
May 27 15:30:45 openfaas-new2 faasd[2610]: Starting queue-worker. Version: 0.11.2        Git Commit: de4adf202a38a031701f0bb698c1ea3b202ca93e
May 27 15:30:45 openfaas-new2 faasd[2610]: Connect: nats://nats:4222
May 27 15:30:45 openfaas-new2 faasd[2610]: 2020/05/27 15:30:45 Supervisor init done in: 1m7.72484887s
May 27 15:30:45 openfaas-new2 faasd[2610]: 2020/05/27 15:30:45 faasd: waiting for SIGTERM or SIGINT
May 27 15:30:45 openfaas-new2 faasd[2610]: [1] 2020/05/27 15:30:45.208616 [INF] STREAM: Channel "faas-request" has been created
May 27 15:30:45 openfaas-new2 faasd[2610]: Subscribing to: faas-request at nats://nats:4222
May 27 15:30:45 openfaas-new2 faasd[2610]: Wait for  5m5s
May 27 15:30:45 openfaas-new2 faasd[2610]: Listening on [faas-request], clientID=[faas-worker-openfaas-new2], qgroup=[faas] maxInFlight=[1]
May 27 15:30:48 openfaas-new2 faasd[2610]: 2020/05/27 15:30:48 [up] Sending 10.62.0.5 to proxy
May 27 15:30:48 openfaas-new2 faasd[2610]: 2020/05/27 15:30:48 Starting faasd proxy on 8080
May 27 15:30:48 openfaas-new2 faasd[2610]: Gateway: 10.62.0.5:8080
May 27 15:30:48 openfaas-new2 faasd[2610]: 2020/05/27 15:30:48 [proxy] Wait for done
May 27 15:30:48 openfaas-new2 faasd[2610]: 2020/05/27 15:30:48 [proxy] Begin listen on 8080
May 27 15:45:21 openfaas-new2 faasd[2610]: [faasd] proxy: http://10.62.0.5:8080/
May 27 15:46:24 openfaas-new2 faasd[2610]: [faasd] proxy: http://10.62.0.5:8080/ui/
May 27 15:46:24 openfaas-new2 faasd[2610]: 2020/05/27 15:46:24 Validated request 401.
May 27 15:46:41 openfaas-new2 faasd[2610]: [faasd] proxy: http://10.62.0.5:8080/ui/
May 27 15:46:41 openfaas-new2 faasd[2610]: 2020/05/27 15:46:41 Validated request 401.
May 27 15:47:33 openfaas-new2 faasd[2610]: [faasd] proxy: http://10.62.0.5:8080/ui/
May 27 15:47:33 openfaas-new2 faasd[2610]: 2020/05/27 15:47:33 Validated request 200.
May 27 15:47:34 openfaas-new2 faasd[2610]: [faasd] proxy: http://10.62.0.5:8080/ui/
May 27 15:47:34 openfaas-new2 faasd[2610]: 2020/05/27 15:47:34 Validated request 200.
May 27 15:47:44 openfaas-new2 faasd[2610]: [faasd] proxy: http://10.62.0.5:8080/ui/style/angular_material/1.1.0/angular-material.min.css


```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Commits:

- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] My commit message has a body and describe how this was tested and why it is required.
- [x] I have signed-off my commits with `git commit -s` for the Developer Certificate of Origin (DCO)

Code:

- [x] My code follows the code style of this project.
- [ ] I have added tests to cover my changes.

Docs:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

