### PR TITLE
Update max_inflight configuration to 5 to enable concurrency

### DIFF
--- a/cmd/up.go
+++ b/cmd/up.go
@@ -251,7 +251,7 @@ func makeServiceDefinitions(archSuffix string) []pkg.Service {
 				"gateway_invoke=true",
 				"faas_gateway_address=gateway",
 				"ack_wait=5m5s",
-				"max_inflight=1",
+				"max_inflight=5",
 				"write_debug=false",
 				"basic_auth=true",
 				"secret_mount_path=" + containerSecretMountDir,


### PR DESCRIPTION
We should set `max_inflight`  configuration  item to 5  to enable concurrency,since it can't be changed without rebuilding

Signed-off-by: Hsiny <yangxinhust@hotmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change **this is required**
Issue war raised by Alex, https://github.com/openfaas/faasd/issues/73


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Commits:

- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] My commit message has a body and describe how this was tested and why it is required.
- [x] I have signed-off my commits with `git commit -s` for the Developer Certificate of Origin (DCO)

Code:

- [x] My code follows the code style of this project.
- [ ] I have added tests to cover my changes.

Docs:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
