### PR TITLE
Moving alexellis/FAASD_MULTIPASS.md Gist into docs folder of this repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ If your IaaS supports `user_data` aka "cloud-init", then this guide is for you. 
 
 ### Run locally on MacOS, Linux, or Windows with Multipass.run
 
-* [Get up and running with your own faasd installation on your Mac/Ubuntu or Windows with cloud-config](https://gist.github.com/alexellis/6d297e678c9243d326c151028a3ad7b9)
+* [Get up and running with your own faasd installation on your Mac/Ubuntu or Windows with cloud-config](docs/FAASD_MULTIPASS.md)
 
 ### Get started on armhf / Raspberry Pi
 

--- a/docs/FAASD_MULTIPASS.md
+++ b/docs/FAASD_MULTIPASS.md
@@ -1,0 +1,142 @@
+> Note: this has now moved to github.com/openfaas/faasd <- check for the latest version
+
+
+## Get up and running with your own faasd installation on your Mac
+
+[multipass from Canoncial](https://multipass.run) is like Docker Desktop, but for getting Ubuntu instead of a Docker daemon. It works on MacOS, Linux, and Windows with the same consistent UX. It's not fully open-source, and uses some proprietary add-ons / binaries, but is free to use.
+
+For Linux using Ubuntu, you can install the packages directly, or use `sudo snap install multipass --classic` and follow this tutorial. For Raspberry Pi, [see my tutorial here](https://blog.alexellis.io/faasd-for-lightweight-serverless/).
+
+John McCabe has also tested faasd on Windows with multipass, [see his tweet](https://twitter.com/mccabejohn/status/1221899154672308224).
+
+## Use-case:
+
+Try out [faasd](https://github.com/openfaas/faasd) in a single command using a cloud-config file to get a VM which has:
+
+* port 22 for administration and
+* port 8080 for the OpenFaaS REST API.
+
+![Example](https://pbs.twimg.com/media/EPNQz00W4AEwDxM?format=jpg&name=medium)
+
+The above screenshot is [from my tweet](https://twitter.com/alexellisuk/status/1221408788395298819/), feel free to comment there.
+
+It took me about 2-3 minutes to run through everything after installing multipass.
+
+## Let's start the tutorial
+
+* Get [multipass.run](https://multipass.run)
+
+* Get my cloud-config.txt file
+
+```sh
+curl -sSLO https://raw.githubusercontent.com/openfaas/faasd/master/cloud-config.txt
+```
+
+* Update the SSH key to match your own, edit `cloud-config.txt`:
+
+Replace the 2nd line with the contents of `~/.ssh/id_rsa.pub`:
+
+```
+ssh_authorized_keys:
+  - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC8Q/aUYUr3P1XKVucnO9mlWxOjJm+K01lHJR90MkHC9zbfTqlp8P7C3J26zKAuzHXOeF+VFxETRr6YedQKW9zp5oP7sN+F2gr/pO7GV3VmOqHMV7uKfyUQfq7H1aVzLfCcI7FwN2Zekv3yB7kj35pbsMa1Za58aF6oHRctZU6UWgXXbRxP+B04DoVU7jTstQ4GMoOCaqYhgPHyjEAS3DW0kkPW6HzsvJHkxvVcVlZ/wNJa1Ie/yGpzOzWIN0Ol0t2QT/RSWOhfzO1A2P0XbPuZ04NmriBonO9zR7T1fMNmmtTuK7WazKjQT3inmYRAqU6pe8wfX8WIWNV7OowUjUsv alex@alexr.local
+```
+
+* Boot the VM
+
+```sh
+multipass launch --cloud-init cloud-config.txt  --name faasd
+```
+
+* Get the VM's IP and connect with `ssh`
+
+```sh
+multipass info faasd
+Name:           faasd
+State:          Running
+IPv4:           192.168.64.14
+Release:        Ubuntu 18.04.3 LTS
+Image hash:     a720c34066dc (Ubuntu 18.04 LTS)
+Load:           0.79 0.19 0.06
+Disk usage:     1.1G out of 4.7G
+Memory usage:   145.6M out of 985.7M
+```
+
+Set the variable `IP`:
+
+```
+export IP="192.168.64.14"
+```
+
+You can also try to use `jq` to get the IP into a variable:
+
+```sh
+export IP=$(multipass info faasd --format json| jq '.info.faasd.ipv4[0]' | tr -d '\"')
+```
+
+Connect to the IP listed:
+
+```sh
+ssh ubuntu@$IP
+```
+
+Log out once you know it works.
+
+* Let's capture the authentication password into a file for use with `faas-cli`
+
+```
+ssh ubuntu@192.168.64.14 "sudo cat /var/lib/faasd/secrets/basic-auth-password" > basic-auth-password
+```
+
+## Try faasd (OpenFaaS)
+
+* Login from your laptop (the host)
+
+```
+export OPENFAAS_URL=http://$IP:8080
+cat basic-auth-password | faas-cli login -s
+```
+
+* Deploy a function and invoke it
+
+```
+faas-cli store deploy figlet --env write_timeout=1s
+echo "faasd" | faas-cli invoke figlet
+
+faas-cli describe figlet
+
+# Run async
+curl -i -d "faasd-async" $OPENFAAS_URL/async-function/figlet
+
+# Run async with a callback
+
+curl -i -d "faasd-async" -H "X-Callback-Url: http://some-request-bin.com/path" $OPENFAAS_URL/async-function/figlet
+```
+
+You can also checkout the other store functions: `faas-cli store list`
+
+* Try the UI
+
+Head over to the UI from your laptop and remember that your password is in the `basic-auth-password` file. The username is `admin.:
+
+```
+echo http://$IP:8080
+```
+
+* Stop/start the instance
+
+```sh
+multipass stop faasd
+```
+
+* Delete, if you want to:
+
+```
+multipass delete --purge faasd
+```
+
+That's it, we're done. You now have a faasd appliance on your Mac. You could probably use this cloud-init file with AWS or DigitalOcean too.
+
+* If you want a public IP for your faasd VM, then just head over to [inlets.dev](https://inlets.dev/)
+* Try my more complete walk-through / tutorial with Raspberry Pi, or run the same steps on your multipass VM, including how to develop your own functions and services - https://blog.alexellis.io/faasd-for-lightweight-serverless/
+* You might also like [Building containers without Docker](https://blog.alexellis.io/building-containers-without-docker/)
+* Star/fork [faasd](https://github.com/openfaas/faasd) on GitHub

--- a/docs/FAASD_MULTIPASS.md
+++ b/docs/FAASD_MULTIPASS.md
@@ -1,9 +1,6 @@
-> Note: this has now moved to github.com/openfaas/faasd <- check for the latest version
-
-
 ## Get up and running with your own faasd installation on your Mac
 
-[multipass from Canoncial](https://multipass.run) is like Docker Desktop, but for getting Ubuntu instead of a Docker daemon. It works on MacOS, Linux, and Windows with the same consistent UX. It's not fully open-source, and uses some proprietary add-ons / binaries, but is free to use.
+[multipass from Canonical](https://multipass.run) is like Docker Desktop, but for getting Ubuntu instead of a Docker daemon. It works on MacOS, Linux, and Windows with the same consistent UX. It's not fully open-source, and uses some proprietary add-ons / binaries, but is free to use.
 
 For Linux using Ubuntu, you can install the packages directly, or use `sudo snap install multipass --classic` and follow this tutorial. For Raspberry Pi, [see my tutorial here](https://blog.alexellis.io/faasd-for-lightweight-serverless/).
 

--- a/docs/FAASD_MULTIPASS.md
+++ b/docs/FAASD_MULTIPASS.md
@@ -84,7 +84,7 @@ Log out once you know it works.
 * Let's capture the authentication password into a file for use with `faas-cli`
 
 ```
-ssh ubuntu@192.168.64.14 "sudo cat /var/lib/faasd/secrets/basic-auth-password" > basic-auth-password
+ssh ubuntu@$IP "sudo cat /var/lib/faasd/secrets/basic-auth-password" > basic-auth-password
 ```
 
 ## Try faasd (OpenFaaS)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- `wget` latest Gist from `gist.github.com/alexellis/6d297e678c9243d326c151028a3ad7b9` into the docs subdirectory of faasd repo
- Change README.md to point to `docs/FAASD_MULTIPASS.md` instead of gist.github.com
- Couple of minor updates to the doc itself


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Following [discussion on the gist](https://gist.github.com/alexellis/6d297e678c9243d326c151028a3ad7b9#gistcomment-3333553) with @alexellis where he mentioned I should be able to find this doc in the repo, I couldn't find in here, which this  PR addresses.

- [x] I have raised an issue to propose this change **this is required**



## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Locally with `markserv`


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Commits:

- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] My commit message has a body and describe how this was tested and why it is required.
- [x] I have signed-off my commits with `git commit -s` for the Developer Certificate of Origin (DCO)

Code:

- [x] My code follows the code style of this project.
- [ ] I have added tests to cover my changes.

Docs:

- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
