### PR TITLE
Add depends_on fields

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -17,6 +17,7 @@ services:
         target: /run/secrets/basic-auth-user
     cap_add:
       - CAP_NET_RAW
+
   nats:
     image: docker.io/library/nats-streaming:0.11.2
     command:
@@ -25,6 +26,7 @@ services:
       - "8222"
       - "--store=memory"
       - "--cluster_id=faas-cluster"
+
   prometheus:
     image: docker.io/prom/prometheus:v2.14.0
     volumes:
@@ -33,6 +35,7 @@ services:
         target: /etc/prometheus/prometheus.yml
     cap_add:
       - CAP_NET_RAW
+
   gateway:
     image: "docker.io/openfaas/gateway:0.18.17${ARCH_SUFFIX}"
     environment:
@@ -58,6 +61,11 @@ services:
         target: /run/secrets/basic-auth-user
     cap_add:
       - CAP_NET_RAW
+    depends_on:
+      - basic-auth-plugin
+      - nats
+      - prometheus
+
   queue-worker:
     image: docker.io/openfaas/queue-worker:0.11.2
     environment:
@@ -80,3 +88,5 @@ services:
         target: /run/secrets/basic-auth-user
     cap_add:
       - CAP_NET_RAW
+    depends_on:
+      - nats

--- a/pkg/cninetwork/weave.go
+++ b/pkg/cninetwork/weave.go
@@ -18,19 +18,6 @@ type Dev struct {
 	CIDRs []*net.IPNet     `json:"CIDRs,omitempty"`
 }
 
-func linkToNetDev(link netlink.Link) (Dev, error) {
-	addrs, err := netlink.AddrList(link, netlink.FAMILY_V4)
-	if err != nil {
-		return Dev{}, err
-	}
-
-	netDev := Dev{Name: link.Attrs().Name, MAC: link.Attrs().HardwareAddr}
-	for _, addr := range addrs {
-		netDev.CIDRs = append(netDev.CIDRs, addr.IPNet)
-	}
-	return netDev, nil
-}
-
 // ConnectedToBridgeVethPeerIds returns peer indexes of veth links connected to
 // the given bridge. The peer index is used to query from a container netns
 // whether the container is connected to the bridge.

--- a/pkg/cninetwork/weave_linux.go
+++ b/pkg/cninetwork/weave_linux.go
@@ -1,0 +1,19 @@
+// +build linux
+
+package cninetwork
+
+import "github.com/vishvananda/netlink"
+
+func linkToNetDev(link netlink.Link) (Dev, error) {
+
+	addrs, err := netlink.AddrList(link, netlink.FAMILY_V4)
+	if err != nil {
+		return Dev{}, err
+	}
+
+	netDev := Dev{Name: link.Attrs().Name, MAC: link.Attrs().HardwareAddr}
+	for _, addr := range addrs {
+		netDev.CIDRs = append(netDev.CIDRs, addr.IPNet)
+	}
+	return netDev, nil
+}

--- a/pkg/cninetwork/weave_mac.go
+++ b/pkg/cninetwork/weave_mac.go
@@ -1,0 +1,10 @@
+// +build darwin
+
+package cninetwork
+
+import "github.com/vishvananda/netlink"
+
+func linkToNetDev(link netlink.Link) (Dev, error) {
+
+	return Dev{}, nil
+}

--- a/pkg/depends_on.go
+++ b/pkg/depends_on.go
@@ -1,0 +1,35 @@
+package pkg
+
+import "fmt"
+
+func buildInstallOrder(svcs []Service) []string {
+	graph := Graph{nodes: []*Node{}}
+
+	nodeMap := map[string]*Node{}
+	for _, s := range svcs {
+		n := &Node{Name: s.Name}
+		nodeMap[s.Name] = n
+		graph.nodes = append(graph.nodes, n)
+	}
+
+	for _, s := range svcs {
+		for _, d := range s.DependsOn {
+			nodeMap[s.Name].Edges = append(nodeMap[s.Name].Edges, nodeMap[d])
+		}
+	}
+
+	resolved := &Graph{}
+	unresolved := &Graph{}
+	for _, g := range graph.nodes {
+		resolve(g, resolved, unresolved)
+	}
+
+	fmt.Printf("Installation order:\n")
+	order := []string{}
+	for _, node := range resolved.nodes {
+		fmt.Printf("- %s\n", node.Name)
+		order = append(order, node.Name)
+	}
+
+	return order
+}

--- a/pkg/depends_on.go
+++ b/pkg/depends_on.go
@@ -1,6 +1,8 @@
 package pkg
 
-import "fmt"
+import (
+	"log"
+)
 
 func buildInstallOrder(svcs []Service) []string {
 	graph := Graph{nodes: []*Node{}}
@@ -24,10 +26,10 @@ func buildInstallOrder(svcs []Service) []string {
 		resolve(g, resolved, unresolved)
 	}
 
-	fmt.Printf("Installation order:\n")
+	log.Printf("Start-up order:\n")
 	order := []string{}
 	for _, node := range resolved.nodes {
-		fmt.Printf("- %s\n", node.Name)
+		log.Printf("- %s\n", node.Name)
 		order = append(order, node.Name)
 	}
 

--- a/pkg/depends_on_test.go
+++ b/pkg/depends_on_test.go
@@ -1,0 +1,224 @@
+package pkg
+
+import (
+	"log"
+	"testing"
+)
+
+func Test_buildInstallOrder_ARequiresB(t *testing.T) {
+	svcs := []Service{
+		{
+			Name:      "A",
+			DependsOn: []string{"B"},
+		},
+		{
+			Name:      "B",
+			DependsOn: []string{},
+		},
+	}
+
+	order := buildInstallOrder(svcs)
+
+	if len(order) < len(svcs) {
+		t.Fatalf("length of order too short: %d", len(order))
+	}
+
+	got := order[0]
+	want := "B"
+	if got != want {
+		t.Fatalf("%s should be last to be installed, but was: %s", want, got)
+	}
+}
+
+func Test_buildInstallOrder_ARequiresBAndC(t *testing.T) {
+	svcs := []Service{
+		{
+			Name:      "A",
+			DependsOn: []string{"B", "C"},
+		},
+		{
+			Name:      "B",
+			DependsOn: []string{},
+		},
+		{
+			Name:      "C",
+			DependsOn: []string{},
+		},
+	}
+
+	order := buildInstallOrder(svcs)
+
+	if len(order) < len(svcs) {
+		t.Fatalf("length of order too short: %d", len(order))
+	}
+
+	a := indexStr(order, "a")
+	b := indexStr(order, "b")
+	c := indexStr(order, "c")
+
+	if a > b {
+		t.Fatalf("a should be after dependencies")
+	}
+	if a > c {
+		t.Fatalf("a should be after dependencies")
+	}
+
+}
+
+func Test_buildInstallOrder_ARequiresBRequiresC(t *testing.T) {
+	svcs := []Service{
+		{
+			Name:      "A",
+			DependsOn: []string{"B"},
+		},
+		{
+			Name:      "B",
+			DependsOn: []string{"C"},
+		},
+		{
+			Name:      "C",
+			DependsOn: []string{},
+		},
+	}
+
+	order := buildInstallOrder(svcs)
+
+	if len(order) < len(svcs) {
+		t.Fatalf("length of order too short: %d", len(order))
+	}
+
+	got := order[0]
+	want := "C"
+	if got != want {
+		t.Fatalf("%s should be last to be installed, but was: %s", want, got)
+	}
+	got = order[1]
+	want = "B"
+	if got != want {
+		t.Fatalf("%s should be last to be installed, but was: %s", want, got)
+	}
+	got = order[2]
+	want = "A"
+	if got != want {
+		t.Fatalf("%s should be last to be installed, but was: %s", want, got)
+	}
+}
+
+func Test_buildInstallOrderCircularARequiresBRequiresA(t *testing.T) {
+	svcs := []Service{
+		{
+			Name:      "A",
+			DependsOn: []string{"B"},
+		},
+		{
+			Name:      "B",
+			DependsOn: []string{"A"},
+		},
+	}
+
+	defer func() { recover() }()
+
+	buildInstallOrder(svcs)
+
+	t.Fatalf("did not panic as expected")
+}
+
+func Test_buildInstallOrderComposeFile(t *testing.T) {
+	// svcs := []Service{}
+	file, err := LoadComposeFileWithArch("../", "docker-compose.yaml", func() (string, string) {
+		return "x86_64", "Linux"
+	})
+
+	if err != nil {
+		t.Fatalf("unable to load compose file: %s", err)
+	}
+
+	svcs, err := ParseCompose(file)
+	if err != nil {
+		t.Fatalf("unable to parse compose file: %s", err)
+	}
+
+	for _, s := range svcs {
+		log.Printf("Service: %s\n", s.Name)
+		for _, d := range s.DependsOn {
+			log.Printf("Link: %s => %s\n", s.Name, d)
+		}
+	}
+
+	order := buildInstallOrder(svcs)
+
+	if len(order) < len(svcs) {
+		t.Fatalf("length of order too short: %d", len(order))
+	}
+
+	queueWorker := indexStr(order, "queue-worker")
+	nats := indexStr(order, "nats")
+	gateway := indexStr(order, "gateway")
+	prometheus := indexStr(order, "prometheus")
+
+	if prometheus > gateway {
+		t.Fatalf("Prometheus order was after gateway, and should be before")
+	}
+	if nats > gateway {
+		t.Fatalf("NATS order was after gateway, and should be before")
+	}
+	if nats > queueWorker {
+		t.Fatalf("NATS order was after queue-worker, and should be before")
+	}
+}
+
+func Test_buildInstallOrderOpenFaaS(t *testing.T) {
+	svcs := []Service{
+		{
+			Name:      "queue-worker",
+			DependsOn: []string{"nats"},
+		},
+		{
+			Name:      "prometheus",
+			DependsOn: []string{},
+		},
+		{
+			Name:      "gateway",
+			DependsOn: []string{"prometheus", "nats", "basic-auth-plugin"},
+		},
+		{
+			Name:      "basic-auth-plugin",
+			DependsOn: []string{},
+		},
+		{
+			Name:      "nats",
+			DependsOn: []string{},
+		},
+	}
+
+	order := buildInstallOrder(svcs)
+
+	if len(order) < len(svcs) {
+		t.Fatalf("length of order too short: %d", len(order))
+	}
+
+	queueWorker := indexStr(order, "queue-worker")
+	nats := indexStr(order, "nats")
+	gateway := indexStr(order, "gateway")
+	prometheus := indexStr(order, "prometheus")
+
+	if prometheus > gateway {
+		t.Fatalf("Prometheus order was after gateway, and should be before")
+	}
+	if nats > gateway {
+		t.Fatalf("NATS order was after gateway, and should be before")
+	}
+	if nats > queueWorker {
+		t.Fatalf("NATS order was after queue-worker, and should be before")
+	}
+}
+
+func indexStr(st []string, t string) int {
+	for n, s := range st {
+		if s == t {
+			return n
+		}
+
+	}
+	return -1
+}

--- a/pkg/graph.go
+++ b/pkg/graph.go
@@ -2,12 +2,57 @@ package pkg
 
 import "log"
 
+// Node represents a node in a Graph with
+// 0 to many edges
+type Node struct {
+	Name  string
+	Edges []*Node
+}
+
+// Graph is a collection of nodes
+type Graph struct {
+	nodes []*Node
+}
+
+// Contains returns true if the target Node is found
+// in its list
+func (g *Graph) Contains(target *Node) bool {
+	for _, g := range g.nodes {
+		if g.Name == target.Name {
+			return true
+		}
+	}
+
+	return false
+}
+
+// Add places a Node into the current Graph
+func (g *Graph) Add(target *Node) {
+	g.nodes = append(g.nodes, target)
+}
+
+// Remove deletes a target Node reference from the
+// list of nodes in the graph
+func (g *Graph) Remove(target *Node) {
+	var found *int
+	for i, n := range g.nodes {
+		if n == target {
+			found = &i
+			break
+		}
+	}
+
+	if found != nil {
+		g.nodes = append(g.nodes[:*found], g.nodes[*found+1:]...)
+	}
+}
+
 // resolve finds the order of dependencies for a graph
 // of nodes.
 // Inspired by algorithm from
 // https://www.electricmonk.nl/log/2008/08/07/dependency-resolving-algorithm/
 func resolve(node *Node, resolved, unresolved *Graph) {
-	unresolved.nodes = append(unresolved.nodes, node)
+	unresolved.Add(node)
 
 	for _, edge := range node.Edges {
 
@@ -24,46 +69,6 @@ func resolve(node *Node, resolved, unresolved *Graph) {
 		}
 	}
 
-	resolved.nodes = append(resolved.nodes, node)
-
+	resolved.Add(node)
 	unresolved.Remove(node)
-}
-
-func newNode(name string, edges []*Node) *Node {
-	return &Node{
-		Name:  name,
-		Edges: edges,
-	}
-}
-
-type Node struct {
-	Name  string
-	Edges []*Node
-}
-
-type Graph struct {
-	nodes []*Node
-}
-
-func (g *Graph) Contains(target *Node) bool {
-	for _, g := range g.nodes {
-		if g.Name == target.Name {
-			return true
-		}
-	}
-
-	return false
-}
-func (g *Graph) Remove(target *Node) {
-	var found *int
-	for i, n := range g.nodes {
-		if n == target {
-			found = &i
-			break
-		}
-	}
-
-	if found != nil {
-		g.nodes = append(g.nodes[:*found], g.nodes[*found+1:]...)
-	}
 }

--- a/pkg/graph.go
+++ b/pkg/graph.go
@@ -1,0 +1,69 @@
+package pkg
+
+import "log"
+
+// resolve finds the order of dependencies for a graph
+// of nodes.
+// Inspired by algorithm from
+// https://www.electricmonk.nl/log/2008/08/07/dependency-resolving-algorithm/
+func resolve(node *Node, resolved, unresolved *Graph) {
+	unresolved.nodes = append(unresolved.nodes, node)
+
+	for _, edge := range node.Edges {
+
+		if !resolved.Contains(edge) && unresolved.Contains(edge) {
+			log.Panicf("edge: %s may be a circular dependency", edge.Name)
+		}
+
+		resolve(edge, resolved, unresolved)
+	}
+
+	for _, r := range resolved.nodes {
+		if r.Name == node.Name {
+			return
+		}
+	}
+
+	resolved.nodes = append(resolved.nodes, node)
+
+	unresolved.Remove(node)
+}
+
+func newNode(name string, edges []*Node) *Node {
+	return &Node{
+		Name:  name,
+		Edges: edges,
+	}
+}
+
+type Node struct {
+	Name  string
+	Edges []*Node
+}
+
+type Graph struct {
+	nodes []*Node
+}
+
+func (g *Graph) Contains(target *Node) bool {
+	for _, g := range g.nodes {
+		if g.Name == target.Name {
+			return true
+		}
+	}
+
+	return false
+}
+func (g *Graph) Remove(target *Node) {
+	var found *int
+	for i, n := range g.nodes {
+		if n == target {
+			found = &i
+			break
+		}
+	}
+
+	if found != nil {
+		g.nodes = append(g.nodes[:*found], g.nodes[*found+1:]...)
+	}
+}

--- a/pkg/graph_test.go
+++ b/pkg/graph_test.go
@@ -1,0 +1,41 @@
+package pkg
+
+import "testing"
+
+func Test_RemoveMedial(t *testing.T) {
+	g := Graph{nodes: []*Node{}}
+	a := &Node{Name: "A"}
+	b := &Node{Name: "B"}
+	c := &Node{Name: "C"}
+
+	g.nodes = append(g.nodes, a)
+	g.nodes = append(g.nodes, b)
+	g.nodes = append(g.nodes, c)
+
+	g.Remove(b)
+
+	for _, n := range g.nodes {
+		if n.Name == b.Name {
+			t.Fatalf("Found deleted node: %s", n.Name)
+		}
+	}
+}
+
+func Test_RemoveFinal(t *testing.T) {
+	g := Graph{nodes: []*Node{}}
+	a := &Node{Name: "A"}
+	b := &Node{Name: "B"}
+	c := &Node{Name: "C"}
+
+	g.nodes = append(g.nodes, a)
+	g.nodes = append(g.nodes, b)
+	g.nodes = append(g.nodes, c)
+
+	g.Remove(c)
+
+	for _, n := range g.nodes {
+		if n.Name == c.Name {
+			t.Fatalf("Found deleted node: %s", c.Name)
+		}
+	}
+}

--- a/pkg/testdata/docker-compose.yaml
+++ b/pkg/testdata/docker-compose.yaml
@@ -1,12 +1,12 @@
 version: "3.7"
 services:
   basic-auth-plugin:
-    image: docker.io/openfaas/basic-auth-plugin:0.18.17
+    image: "docker.io/openfaas/basic-auth-plugin:0.18.17${ARCH_SUFFIX}"
     environment:
-      port: "8080"
-      secret_mount_path: "/run/secrets"
-      user_filename: "basic-auth-user"
-      pass_filename: "basic-auth-password"
+      - port=8080
+      - secret_mount_path=/run/secrets
+      - user_filename=basic-auth-user
+      - pass_filename=basic-auth-password
     volumes:
       # we assume cwd == /var/lib/faasd
       - type: bind
@@ -17,6 +17,7 @@ services:
         target: /run/secrets/basic-auth-user
     cap_add:
       - CAP_NET_RAW
+
   nats:
     image: docker.io/library/nats-streaming:0.11.2
     command:
@@ -25,6 +26,7 @@ services:
       - "8222"
       - "--store=memory"
       - "--cluster_id=faas-cluster"
+
   prometheus:
     image: docker.io/prom/prometheus:v2.14.0
     volumes:
@@ -33,21 +35,22 @@ services:
         target: /etc/prometheus/prometheus.yml
     cap_add:
       - CAP_NET_RAW
+
   gateway:
-    image: docker.io/openfaas/gateway:0.18.17
+    image: "docker.io/openfaas/gateway:0.18.17${ARCH_SUFFIX}"
     environment:
-      basic_auth: "true"
-      functions_provider_url: "http://faasd-provider:8081/"
-      direct_functions: "false"
-      read_timeout: "60s"
-      write_timeout: "60s"
-      upstream_timeout: "65s"
-      faas_nats_address: "nats"
-      faas_nats_port: "4222"
-      auth_proxy_url: "http://basic-auth-plugin:8080/validate"
-      auth_proxy_pass_body: "false"
-      secret_mount_path: "/run/secrets"
-      scale_from_zero: "true"
+      - basic_auth=true
+      - functions_provider_url=http://faasd-provider:8081/
+      - direct_functions=false
+      - read_timeout=60s
+      - write_timeout=60s
+      - upstream_timeout=65s
+      - faas_nats_address=nats
+      - faas_nats_port=4222
+      - auth_proxy_url=http://basic-auth-plugin:8080/validate
+      - auth_proxy_pass_body=false
+      - secret_mount_path=/run/secrets
+      - scale_from_zero=true
     volumes:
       # we assume cwd == /var/lib/faasd
       - type: bind
@@ -58,18 +61,23 @@ services:
         target: /run/secrets/basic-auth-user
     cap_add:
       - CAP_NET_RAW
+    depends_on:
+      - basic-auth-plugin
+      - nats
+      - prometheus
+
   queue-worker:
     image: docker.io/openfaas/queue-worker:0.11.2
     environment:
-      faas_nats_address: "nats"
-      faas_nats_port: "4222"
-      gateway_invoke: "true"
-      faas_gateway_address: "gateway"
-      ack_wait: "5m5s"
-      max_inflight: "1"
-      write_debug: "false"
-      basic_auth: "true"
-      secret_mount_path: "/run/secrets"
+      - faas_nats_address=nats
+      - faas_nats_port=4222
+      - gateway_invoke=true
+      - faas_gateway_address=gateway
+      - ack_wait=5m5s
+      - max_inflight=1
+      - write_debug=false
+      - basic_auth=true
+      - secret_mount_path=/run/secrets
     volumes:
       # we assume cwd == /var/lib/faasd
       - type: bind
@@ -80,3 +88,5 @@ services:
         target: /run/secrets/basic-auth-user
     cap_add:
       - CAP_NET_RAW
+    depends_on:
+      - nats


### PR DESCRIPTION
Signed-off-by: Alex Ellis (OpenFaaS Ltd) <alexellis2@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

* Adds depends_on fields to compose YAML
* Adds algorithm and unit tests for finding order
* Applies order to `up.go` command
* Makes unit testing on MacOS possible through build directives

## Motivation and Context

Fixes: #82 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested with unit tests and manually on RPi 3 - problem presented before, and went away after.

```
Jun 17 12:19:05 faasd-pi faasd[17888]: Installation order:
Jun 17 12:19:05 faasd-pi faasd[17888]: - nats
Jun 17 12:19:05 faasd-pi faasd[17888]: - prometheus
Jun 17 12:19:05 faasd-pi faasd[17888]: - gateway
Jun 17 12:19:05 faasd-pi faasd[17888]: - queue-worker
Jun 17 12:19:05 faasd-pi faasd[17888]: - basic-auth-plugin
```