### PR TITLE
Annotation support

### DIFF
--- a/pkg/provider/handlers/deploy_test.go
+++ b/pkg/provider/handlers/deploy_test.go
@@ -1,0 +1,63 @@
+package handlers
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+
+	"github.com/openfaas/faas-provider/types"
+)
+
+func Test_BuildLabels_WithAnnotations(t *testing.T) {
+	// Test each combination of nil/non-nil annotation + label
+	tables := []struct {
+		label      map[string]string
+		annotation map[string]string
+		result     map[string]string
+	}{
+		{nil, nil, map[string]string{}},
+		{map[string]string{"L1": "V1"}, nil, map[string]string{"L1": "V1"}},
+		{nil, map[string]string{"A1": "V2"}, map[string]string{fmt.Sprintf("%sA1", annotationLabelPrefix): "V2"}},
+		{
+			map[string]string{"L1": "V1"}, map[string]string{"A1": "V2"},
+			map[string]string{"L1": "V1", fmt.Sprintf("%sA1", annotationLabelPrefix): "V2"},
+		},
+	}
+
+	for _, pair := range tables {
+
+		request := &types.FunctionDeployment{
+			Labels:      &pair.label,
+			Annotations: &pair.annotation,
+		}
+
+		val, err := buildLabels(request)
+
+		if err != nil {
+			t.Fatalf("want: no error got: %v", err)
+		}
+
+		if !reflect.DeepEqual(val, pair.result) {
+			t.Errorf("Got: %s, expected %s", val, pair.result)
+		}
+	}
+
+}
+
+func Test_BuildLabels_WithAnnotationCollision(t *testing.T) {
+	request := &types.FunctionDeployment{
+		Labels: &map[string]string{
+			"function_name": "echo",
+			fmt.Sprintf("%scurrent-time", annotationLabelPrefix): "Wed 25 Jul 06:41:43 BST 2018",
+		},
+		Annotations: &map[string]string{"current-time": "Wed 25 Jul 06:41:43 BST 2018"},
+	}
+
+	val, err := buildLabels(request)
+
+	fmt.Printf("%s, %s\n", val, err)
+	if err == nil {
+		t.Errorf("Expected an error, got %d values", len(val))
+	}
+
+}

--- a/pkg/provider/handlers/functions_test.go
+++ b/pkg/provider/handlers/functions_test.go
@@ -1,0 +1,29 @@
+package handlers
+
+import (
+	"fmt"
+	"testing"
+)
+
+func Test_BuildLabelsAndAnnotationsFromServiceSpec_Annotations(t *testing.T) {
+	container := map[string]string{
+		"qwer": "ty",
+		"dvor": "ak",
+		fmt.Sprintf("%scurrent-time", annotationLabelPrefix): "5 Nov 20:10:20 PST 1955",
+		fmt.Sprintf("%sfuture-time", annotationLabelPrefix):  "21 Oct 20:10:20 PST 2015",
+	}
+
+	labels, annotation := buildLabelsAndAnnotations(container)
+
+	if len(labels) != 2 {
+		t.Errorf("want: %d labels got: %d", 2, len(labels))
+	}
+
+	if len(annotation) != 2 {
+		t.Errorf("want: %d annotation got: %d", 1, len(annotation))
+	}
+
+	if _, ok := annotation["current-time"]; !ok {
+		t.Errorf("want: '%s' entry in annotation map got: key not found", "current-time")
+	}
+}

--- a/pkg/provider/handlers/read.go
+++ b/pkg/provider/handlers/read.go
@@ -21,12 +21,14 @@ func MakeReadHandler(client *containerd.Client) func(w http.ResponseWriter, r *h
 			return
 		}
 		for _, function := range funcs {
+
 			res = append(res, types.FunctionStatus{
-				Name:      function.name,
-				Image:     function.image,
-				Replicas:  uint64(function.replicas),
-				Namespace: function.namespace,
-				Labels:    &function.labels,
+				Name:        function.name,
+				Image:       function.image,
+				Replicas:    uint64(function.replicas),
+				Namespace:   function.namespace,
+				Labels:      &function.labels,
+				Annotations: &function.annotations,
 			})
 		}
 

--- a/pkg/provider/handlers/replicas.go
+++ b/pkg/provider/handlers/replicas.go
@@ -22,6 +22,7 @@ func MakeReplicaReaderHandler(client *containerd.Client) func(w http.ResponseWri
 				Replicas:          uint64(f.replicas),
 				Namespace:         f.namespace,
 				Labels:            &f.labels,
+				Annotations:       &f.annotations,
 			}
 
 			functionBytes, _ := json.Marshal(found)


### PR DESCRIPTION
Provide support for annotations in faasd with namespaced container
labels

Signed-off-by: Alex Tomic <atomic777@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Annotations are supported in other flavours of openfaas
<!--- If it fixes an open issue, please link to the issue here. -->
https://github.com/openfaas/faasd/issues/51
- [ ] I have raised an issue to propose this change **this is required**


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I have provided new unit tests and ran an end to end test with faasd deployed to a multipass managed VM, with the following simple configuration:
```yaml
version: 1.0                         
provider:                            
  name: openfaas                     
  gateway: http://127.0.0.1:8080     
functions:                           
  figlet-test:                       
    lang: dockerfile                 
    image: functions/figlet:0.13.0   
    labels:                          
      lab1: "val1"                   
    annotations:                     
      foo: "bar"                     
      qwer: "ty"                     
```
Doing a GET to `/system/function/figlet-test` comes back with the annotation:

```json
{
  "name": "figlet-test",
  "image": "",
  "invocationCount": 0,
  "replicas": 1,
  "envProcess": "",
  "availableReplicas": 1,
  "labels": {
    "lab1": "val1"
  },
  "annotations": {
    "foo": "bar",
    "qwer": "ty"
  },
  "namespace": "openfaas-fn"
}
```


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Commits:

- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] My commit message has a body and describe how this was tested and why it is required.
- [x] I have signed-off my commits with `git commit -s` for the Developer Certificate of Origin (DCO)

Code:

- [x] My code follows the code style of this project.
- [x] I have added tests to cover my changes.

Docs:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
