### PR TITLE
Handle race condition with journalctl

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ ARCH := amd64
 all: local
 
 local:
-	CGO_ENABLED=0 GOOS=linux go build -o bin/faasd
+	CGO_ENABLED=0 GOOS=linux go build -ldflags $(LDFLAGS) -o bin/faasd
 
 .PHONY: test
 test:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- Enable the log query stream to wait for the stdout to (re)fill.
  Previously it was possible to try and read the stdout out from
  journalctl before it had written anything. When this happend, the
  stream would be closed. Now, we use the peek behavior of `More` to
  check if there is any new content before we try to decode.
  Additionally, we will read until the context is cancelled. This
  will happen due to the request being cancelled or by the default
  timeout the log provider sets.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [ ] I have raised an issue to propose this change **this is required**

#98
#68 
#51


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
A new unit test has been added. Additionally, using the enviroment setup instructions from the DEV.md, I have been able to consistently get logs from the `nodeinfo` function.

After setting and starting the default environment, i then use to compile and test the branch

```sh
make local \
    && sudo pkill -9 faasd \
    && sudo cp bin/faasd /usr/local/bin \
    && sudo faasd install

faas-cli remove nodeinfo
faas-cli store deploy nodeinfo
faas-cli invoke nodeinfo <<< ""
faas-cli invoke nodeinfo <<< ""
faas-cli logs nodeinfo
```


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Commits:

- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] My commit message has a body and describe how this was tested and why it is required.
- [x] I have signed-off my commits with `git commit -s` for the Developer Certificate of Origin (DCO)

Code:

- [x] My code follows the code style of this project.
- [x] I have added tests to cover my changes.

Docs:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
