### PR TITLE
Restart stopped tasks

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,7 +1,7 @@
 version: "3.7"
 services:
   basic-auth-plugin:
-    image: "docker.io/openfaas/basic-auth-plugin:0.18.17${ARCH_SUFFIX}"
+    image: "docker.io/openfaas/basic-auth-plugin:0.18.18${ARCH_SUFFIX}"
     environment:
       - port=8080
       - secret_mount_path=/run/secrets
@@ -41,7 +41,7 @@ services:
        - "127.0.0.1:9090:9090"
 
   gateway:
-    image: "docker.io/openfaas/gateway:0.18.17${ARCH_SUFFIX}"
+    image: "docker.io/openfaas/gateway:0.18.18${ARCH_SUFFIX}"
     environment:
       - basic_auth=true
       - functions_provider_url=http://faasd-provider:8081/

--- a/pkg/provider/handlers/functions.go
+++ b/pkg/provider/handlers/functions.go
@@ -68,6 +68,7 @@ func GetFunction(client *containerd.Client, name string) (Function, error) {
 			if err != nil {
 				return Function{}, fmt.Errorf("unable to get task status for container: %s %s", name, err)
 			}
+
 			if svc.Status == "running" {
 				replicas = 1
 				f.pid = task.Pid()
@@ -85,7 +86,7 @@ func GetFunction(client *containerd.Client, name string) (Function, error) {
 
 		f.replicas = replicas
 		return f, nil
-
 	}
+
 	return Function{}, fmt.Errorf("unable to find function: %s, error %s", name, err)
 }

--- a/pkg/provider/handlers/scale.go
+++ b/pkg/provider/handlers/scale.go
@@ -101,12 +101,14 @@ func MakeReplicaUpdateHandler(client *containerd.Client, cni gocni.CNI) func(w h
 					if resumeErr := task.Resume(ctx); resumeErr != nil {
 						log.Printf("[Scale] error resuming task %s, error: %s\n", name, resumeErr)
 						http.Error(w, resumeErr.Error(), http.StatusBadRequest)
+						return
 					}
 				} else if taskStatus.Status == containerd.Stopped {
 					// Stopped tasks cannot be restarted, must be removed, and created again
 					if _, delErr := task.Delete(ctx); delErr != nil {
 						log.Printf("[Scale] error deleting stopped task %s, error: %s\n", name, delErr)
 						http.Error(w, delErr.Error(), http.StatusBadRequest)
+						return
 					}
 					createNewTask = true
 				}
@@ -121,7 +123,6 @@ func MakeReplicaUpdateHandler(client *containerd.Client, cni gocni.CNI) func(w h
 				log.Printf("[Scale] error deploying %s, error: %s\n", name, deployErr)
 				http.Error(w, deployErr.Error(), http.StatusBadRequest)
 				return
-
 			}
 		}
 	}


### PR DESCRIPTION
## Description

Restart stopped tasks

## Motivation

This patch reports stopped tasks as having zero scale, which
means the gateway will send a "scale up" request, the same
way as it does for paused containers, or those which have
no task due to a reboot of the machine.

The scale up logic will now delete the stopped task and
recreate the task.

## Testing

Tested with nodeinfo and figlet on a Dell XPS with
Ubuntu 16.04. The scaling logic has been re-written, but
re-tested by manually pausing and manually removing
the task of a container.

Signed-off-by: Alex Ellis (OpenFaaS Ltd) <alexellis2@gmail.com>

Also required for #108 which left containers in a stopped state after they hit their hard memory limit. They will now restart upon a subsequent request coming in.