### PR TITLE
Do a shallow checkout of version 0.9.5 of faasd in cloud-init.

### DIFF
--- a/cloud-config.txt
+++ b/cloud-config.txt
@@ -17,7 +17,7 @@ runcmd:
 - mkdir -p /opt/cni/bin
 - curl -sSL https://github.com/containernetworking/plugins/releases/download/v0.8.5/cni-plugins-linux-amd64-v0.8.5.tgz | tar -xz -C /opt/cni/bin
 - mkdir -p /go/src/github.com/openfaas/
-- cd /go/src/github.com/openfaas/ && git clone https://github.com/openfaas/faasd && git checkout 0.9.5
+- cd /go/src/github.com/openfaas/ && git clone --depth 1 --branch 0.9.5 https://github.com/openfaas/faasd
 - curl -fSLs "https://github.com/openfaas/faasd/releases/download/0.9.5/faasd" --output "/usr/local/bin/faasd" && chmod a+x "/usr/local/bin/faasd"
 - cd /go/src/github.com/openfaas/faasd/ && /usr/local/bin/faasd install
 - systemctl status -l containerd --no-pager


### PR DESCRIPTION
Replace the current git checkout with a checkout of the specific
version and limit the depth to 1 for the installation.

Signed-off-by: Christopher De Vries <devries@idolstarastronomer.com>

## Description
As I ran through the cloud-init I found that the "git checkout 0.9.5" line
currently included in line 20 would not function as it is run from the
wrong directory. I decided to clone the specific version required in
one close command, and also limit the depth of the clone to 
make it more efficient.

## Motivation and Context
Although the cloud-init method of installation does not fail completely, this
change fulfills the intent of the cloud-init installation and also increases
its efficiency as the codebase grows larger.
- [x] I have raised an issue to propose this change **this is required**


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I tested this using multipass under MacOS using the command:

```
multipass launch -c 1 -m 2G -d 10G -n faasd --cloud-init cloud-config.txt
```

The resulting faasd installation was running when cloud-init completed and
I was able to run the figlet function.


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Commits:

- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] My commit message has a body and describe how this was tested and why it is required.
- [x] I have signed-off my commits with `git commit -s` for the Developer Certificate of Origin (DCO)

Code:

- [x] My code follows the code style of this project.
- [ ] I have added tests to cover my changes.

Docs:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
