### PR TITLE
Set Content-Type the same as set and returned by the function

### DIFF
--- a/vendor/github.com/openfaas/faas-provider/proxy/proxy.go
+++ b/vendor/github.com/openfaas/faas-provider/proxy/proxy.go
@@ -225,7 +225,7 @@ func copyHeaders(destination http.Header, source *http.Header) {
 }
 
 // getContentType resolves the correct Content-Type for a proxied function.
-func getContentType(request http.Header, proxyResponse http.Header) (headerContentType string) {
+func getContentType(proxyResponse http.Header, request http.Header) (headerContentType string) {
 	responseHeader := proxyResponse.Get("Content-Type")
 	requestHeader := request.Get("Content-Type")
 


### PR DESCRIPTION
Fixes #136

Signed-off-by: Utsav Anand <utsavanand2@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Usually the signature of http server functions written in Go are like `(response, request)`, but the definition of
the function `getContentType` was originally like (request, proxyResponse), but was called like the first case.
Switching the two arguments has fixed this issue.

Although the change was made in the faas-provider code in the vendor directory, meaning it's a problem in upstream, but even though faas-netes uses faas-provider, it behaves like it is supposed to (I've tested it).

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
~- [ ] I have raised an issue to propose this change **this is required**~
Fixes: #136 


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested with a golang function with `--lang go` which uses the classic-watchdog

<img width="961" alt="Screenshot 2020-12-09 at 7 59 58 PM" src="https://user-images.githubusercontent.com/25264581/101656238-7e9a8e00-3a68-11eb-8acc-6626340aebe4.png">
<img width="657" alt="Screenshot 2020-12-09 at 8 19 53 PM" src="https://user-images.githubusercontent.com/25264581/101656256-82c6ab80-3a68-11eb-82d9-5c9d9bb4ba62.png">



## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Commits:

- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] My commit message has a body and describe how this was tested and why it is required.
- [x] I have signed-off my commits with `git commit -s` for the Developer Certificate of Origin (DCO)

Code:

- [x] My code follows the code style of this project.
- [ ] I have added tests to cover my changes.

Docs:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
