### PR TITLE
Terraform future: Pin to minimum 0.13

### DIFF
--- a/docs/bootstrap/digitalocean-terraform/main.tf
+++ b/docs/bootstrap/digitalocean-terraform/main.tf
@@ -1,5 +1,12 @@
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+  
+  required_providers {
+    digitalocean = {
+      source = "digitalocean/digitalocean"
+      version = "2.3.0"
+    }
+  }
 }
 
 variable "do_token" {


### PR DESCRIPTION
(Alternative / Future) Fixes #141

## Description

Once ready to drop support for 0.12, this branch provides nice error messages to the end user letting them know they need a newer terraform.

## Motivation and Context
- [X] I have raised an issue to propose this change **this is required**


## How Has This Been Tested?

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [X] I have raised an issue to propose this change **this is required**
_Note: the issue doesn't mention this solution. Writing it made a "lightbulb moment" occur._

## How Has This Been Tested?

Linux, Windows OSx using terraform 0.12, 0.13, 0.14 running `terraform init`, seeing expected output

* 0.12 rejects as 0.13 is the minimum supported terraform version for these changes
* 0.13 works.
* 0.14 works.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Adjust dependency pinning for better error message outcomes

## Checklist:

Commits:

- [X] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [X] My commit message has a body and describe how this was tested and why it is required.
- [X] I have signed-off my commits with `git commit -s` for the Developer Certificate of Origin (DCO)

Code:

- [X] My code follows the code style of this project.
- [ ] I have added tests to cover my changes.
- [X] My code uses tests supported in an upstream repo

Docs:

- [ ] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
