### PR TITLE
Pre-pull images during function updates

### DIFF
--- a/pkg/provider/handlers/update.go
+++ b/pkg/provider/handlers/update.go
@@ -57,7 +57,7 @@ func MakeUpdateHandler(client *containerd.Client, cni gocni.CNI, secretMountPath
 
 		ctx := namespaces.WithNamespace(context.Background(), faasd.FunctionNamespace)
 
-		if err := prepull(ctx, req, client, alwaysPull); err != nil {
+		if _, err := prepull(ctx, req, client, alwaysPull); err != nil {
 			log.Printf("[Update] error with pre-pull: %s, %s\n", name, err)
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 		}


### PR DESCRIPTION
Signed-off-by: Alex Ellis (OpenFaaS Ltd) <alexellis2@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Pre-pull images during function updates

## Motivation and Context

The update flow used to delete the active function before
synchronously pulling the next and starting it. That meant
functions would always face downtime during the pull.

This changes the order to pre-pull and reduce any down time.

## How Has This Been Tested?

Tested with the nodeinfo command and my Raspberry Pi after having run `make dist`

The downtime was much smaller and I could keep hitting the function whilst the pre-pull was executing.

Doing a "cold" deploy is still unaffected compared to before.

```
Dec 31 18:47:47 faasd-pi faasd[27371]: 2020/12/31 18:47:47 [Update] request: {"service":"nodeinfo","image":"functions/nodeinfo-http:latest-armhf","network":"","envProcess":"","envVars":{},"constraints":[],"secrets":[],"labels":{},"annotations":{},"limits":null,"requests":null,"readOnlyRootFilesystem":false}

Dec 31 18:47:51 faasd-pi faasd[27371]: 2020/12/31 18:47:51 [Prepull] Deploy docker.io/functions/nodeinfo-http:latest-armhf size: 34303080, took: 3.610425s

Dec 31 18:47:51 faasd-pi faasd[27371]: 2020/12/31 18:47:51 [Delete] removing CNI network for: nodeinfo

Dec 31 18:47:52 faasd-pi faasd[27371]: 2020/12/31 18:47:52 [Delete] removed: nodeinfo from namespace: /proc/27125/ns/net, ID: nodeinfo-27125

Dec 31 18:47:52 faasd-pi faasd[27371]: Status of nodeinfo is: running
Dec 31 18:47:52 faasd-pi faasd[27371]: 2020/12/31 18:47:52 Need to kill nodeinfo
Dec 31 18:47:52 faasd-pi faasd[27371]: 2020/12/31 18:47:52 [deploy] Deploy docker.io/functions/nodeinfo-http:latest-armhf size: 34303080, took: 0.014315s

Dec 31 18:47:53 faasd-pi faasd[27371]: 2020/12/31 18:47:53 Container ID: nodeinfo        Task ID nodeinfo:        Task PID: 28343
Dec 31 18:47:53 faasd-pi faasd[27371]: 2020/12/31 18:47:53 nodeinfo has IP: 10.62.1.197.
```

We see a 3.6s forced pull for the nodeinfo function, followed by a second rapid lookup in the deploy method of 0.014s.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Reliability improvement
