### PR TITLE
Use the openfaas namespace for core services

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,14 +125,16 @@ echo logs | faas-cli invoke figlet
 
 Core services as defined in the docker-compose.yaml file are deployed as containers by faasd.
 
+The namespace is `openfaas` for core services.
+
 View the logs for a component by giving its NAME:
 
 ```bash
-journalctl -t default:NAME
+journalctl -t openfaas:NAME
 
-journalctl -t default:gateway
+journalctl -t openfaas:gateway
 
-journalctl -t default:queue-worker
+journalctl -t openfaas:queue-worker
 ```
 
 You can also use `-f` to follow the logs, or `--lines` to tail a number of lines, or `--since` to give a timeframe.

--- a/pkg/constants.go
+++ b/pkg/constants.go
@@ -3,4 +3,11 @@ package pkg
 const (
 	// FunctionNamespace is the default containerd namespace functions are created
 	FunctionNamespace = "openfaas-fn"
+
+	// faasdNamespace is the containerd namespace services are created
+	faasdNamespace = "openfaas"
+
+	faasServicesPullAlways = false
+
+	defaultSnapshotter = "overlayfs"
 )

--- a/pkg/supervisor.go
+++ b/pkg/supervisor.go
@@ -26,11 +26,7 @@ import (
 )
 
 const (
-	defaultSnapshotter         = "overlayfs"
 	workingDirectoryPermission = 0644
-	// faasdNamespace is the containerd namespace services are created
-	faasdNamespace         = "default"
-	faasServicesPullAlways = false
 )
 
 type Service struct {


### PR DESCRIPTION
Signed-off-by: Alex Ellis (OpenFaaS Ltd) <alexellis2@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

All services like docker and k8s.io use their own namespaces
for core services, this change moves openfaas services into
the openfaas namespace instead of the default one.

The main change is that logs will look like:

journalctl -t openfaas:gateway

Instead of "default:gateway"

Function logs will remain unaffected and scheduled in the
openfaas-fn namespace.

## Motivation and Context

This change brings consistency with other consumers of containerd

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

The change will be tested via CI

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

To most users this will be an invisible change, however some users may end up with two versions of the core services when upgrading. To avoid this, make sure you remove the containers and tasks in the default namespace before upgrading.

```
sudo ctr container ls/rm --force
sudo ctr task ls/rm
```
