### PR TITLE
Add user support for custom containers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,4 +62,5 @@ test-e2e:
 	sleep 3
 	/usr/local/bin/faas-cli list
 	sleep 3
-	/usr/local/bin/faas-cli logs figlet --follow=false | grep Forking
+	journalctl -t openfaas-fn:figlet --no-pager
+	/usr/local/bin/faas-cli logs figlet --since 15m --follow=false | grep Forking


### PR DESCRIPTION
Signed-off-by: Alex Ellis (OpenFaaS Ltd) <alexellis2@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Add user support for custom containers

## Motivation and Context

Custom containers in the compose file can have a directory
mounted to store state for things like a database. This requires
a specific user since influxdb/postgresql and other containers
create folders and update permissions on start-up.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested with influxdb on Ubuntu with userid 1000, which failed
before the change.

```yaml
  influxdb:
    image: docker.io/library/influxdb:1.7
    environment:
      - INFLUXDB_ADMIN_USER=admin
    volumes:
      # we assume cwd == /var/lib/faasd
      - type: bind
        source: ./influxdb/
        target: /var/lib/influxdb
    user: "1000" 
    cap_add:
      - CAP_NET_RAW
    ports:
      - "8086:8086"
```

Create a persistent data volume:

```
sudo mkdir -p /var/lib/faasd/influxdb
```

Make the folder readable by the user ID we are running as:

```
sudo chown 1000:1000 /var/lib/faasd/influxdb
```

Restart faasd:

```
sudo systemctl daemon-reload \
  && sudo systemctl restart faasd
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
