### PR TITLE
Populate Map of EnvVars and envProcess in status endpoint

### DIFF
--- a/pkg/provider/handlers/functions_test.go
+++ b/pkg/provider/handlers/functions_test.go
@@ -60,20 +60,26 @@ func Test_ProcessEnvToEnvVars(t *testing.T) {
 		Name     string
 		Input    []string
 		Expected map[string]string
+		fprocess string
 	}
 	tests := []test{
-		{Name: "No matching EnvVars", Input: []string{"PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin", "fprocess=python", "index.py"}, Expected: make(map[string]string)},
-		{Name: "No EnvVars", Input: []string{}, Expected: make(map[string]string)},
-		{Name: "One EnvVar", Input: []string{"PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin", "fprocess=python", "env=this", "index.py"}, Expected: map[string]string{"env": "this"}},
-		{Name: "Multiple EnvVars", Input: []string{"PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin", "this=that", "env=var", "fprocess=python", "index.py"}, Expected: map[string]string{"this": "that", "env": "var"}},
+		{Name: "No matching EnvVars", Input: []string{"PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin", "fprocess=python index.py"}, Expected: make(map[string]string), fprocess: "python index.py"},
+		{Name: "No EnvVars", Input: []string{}, Expected: make(map[string]string), fprocess: ""},
+		{Name: "One EnvVar", Input: []string{"PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin", "fprocess=python index.py", "env=this"}, Expected: map[string]string{"env": "this"}, fprocess: "python index.py"},
+		{Name: "Multiple EnvVars", Input: []string{"PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin", "this=that", "env=var", "fprocess=python index.py"}, Expected: map[string]string{"this": "that", "env": "var"}, fprocess: "python index.py"},
 		{Name: "Nil EnvVars", Input: nil, Expected: make(map[string]string)},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.Name, func(t *testing.T) {
-			got := readEnvVarsFromProcessEnv(tc.Input)
+			got, fprocess := readEnvFromProcessEnv(tc.Input)
 			if !reflect.DeepEqual(got, tc.Expected) {
-				t.Fatalf("expected %s, got %s", tc.Expected, got)
+				t.Fatalf("expected: %s, got: %s", tc.Expected, got)
+			}
+
+			if fprocess != tc.fprocess {
+				t.Fatalf("expected fprocess: %s, got: %s", tc.fprocess, got)
+
 			}
 		})
 	}

--- a/pkg/provider/handlers/read.go
+++ b/pkg/provider/handlers/read.go
@@ -33,6 +33,7 @@ func MakeReadHandler(client *containerd.Client) func(w http.ResponseWriter, r *h
 				Annotations: annotations,
 				Secrets:     fn.secrets,
 				EnvVars:     fn.envVars,
+				EnvProcess:  fn.envProcess,
 			})
 		}
 

--- a/pkg/provider/handlers/read.go
+++ b/pkg/provider/handlers/read.go
@@ -32,6 +32,7 @@ func MakeReadHandler(client *containerd.Client) func(w http.ResponseWriter, r *h
 				Labels:      labels,
 				Annotations: annotations,
 				Secrets:     fn.secrets,
+				EnvVars:     fn.envVars,
 			})
 		}
 

--- a/pkg/provider/handlers/replicas.go
+++ b/pkg/provider/handlers/replicas.go
@@ -25,6 +25,7 @@ func MakeReplicaReaderHandler(client *containerd.Client) func(w http.ResponseWri
 				Annotations:       &f.annotations,
 				Secrets:           f.secrets,
 				EnvVars:           f.envVars,
+				EnvProcess:        f.envProcess,
 			}
 
 			functionBytes, _ := json.Marshal(found)

--- a/pkg/provider/handlers/replicas.go
+++ b/pkg/provider/handlers/replicas.go
@@ -24,6 +24,7 @@ func MakeReplicaReaderHandler(client *containerd.Client) func(w http.ResponseWri
 				Labels:            &f.labels,
 				Annotations:       &f.annotations,
 				Secrets:           f.secrets,
+				EnvVars:           f.envVars,
 			}
 
 			functionBytes, _ := json.Marshal(found)


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

This commit adds the EnvVars set and envProcess string on the process to the retuurn from the
faasd provider. It gets the container process and then filters out PATH
and fprocess (if found) and returns the remaining envVars as a map.

Signed-off-by: Alistair Hey <alistair@heyal.co.uk>

<!--- Provide a general summary of your changes in the Title above -->



## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [ ] I have raised an issue to propose this change **this is required**
Ongoing improvement work

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

This has using tests for getting the EnvVars from procees.env and has
been tested on amd_64 faasd by building, deploying and using curl
against the provider and gateway.


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Commits:

- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] My commit message has a body and describe how this was tested and why it is required.
- [x] I have signed-off my commits with `git commit -s` for the Developer Certificate of Origin (DCO)

Code:

- [x] My code follows the code style of this project.
- [x] I have added tests to cover my changes.

Docs:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
