### PR TITLE
Add function_namespace to gateway env vars

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -55,6 +55,7 @@ services:
       - auth_proxy_pass_body=false
       - secret_mount_path=/run/secrets
       - scale_from_zero=true
+      - function_namespace=openfaas-fn
     volumes:
       # we assume cwd == /var/lib/faasd
       - type: bind


### PR DESCRIPTION
This adds the function_namespace environment variable to the gateway
container. This is used for metrics in prometheus.


Signed-off-by: Alistair Hey <alistair@heyal.co.uk>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [ ] I have raised an issue to propose this change **this is required**
Fixes invocation cont not increasing in the Gateway UI.


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested this config setting in a multipass instance and now the metrics
are updating on the gateway UI and CLI. Before this the metrics were
entering the prom series with "fn-name" and being retrieved with
"fn-name.namespace" and therefore there were always 0 invocations seen.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Commits:

- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] My commit message has a body and describe how this was tested and why it is required.
- [x] I have signed-off my commits with `git commit -s` for the Developer Certificate of Origin (DCO)

Code:

- [x] My code follows the code style of this project.
- [ ] I have added tests to cover my changes.

Docs:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
