### PR TITLE
add git to cloud-init

### DIFF
--- a/cloud-config.txt
+++ b/cloud-config.txt
@@ -7,6 +7,7 @@ package_update: true
 
 packages:
  - runc
+ - git
 
 runcmd:
 - curl -sLSf https://github.com/containerd/containerd/releases/download/v1.3.5/containerd-1.3.5-linux-amd64.tar.gz > /tmp/containerd.tar.gz && tar -xvf /tmp/containerd.tar.gz -C /usr/local/bin/ --strip-components=1

--- a/docs/bootstrap/cloud-config.tpl
+++ b/docs/bootstrap/cloud-config.tpl
@@ -7,6 +7,7 @@ package_update: true
 
 packages:
  - runc
+ - git
 
 runcmd:
 - curl -sLSf https://github.com/containerd/containerd/releases/download/v1.3.5/containerd-1.3.5-linux-amd64.tar.gz > /tmp/containerd.tar.gz && tar -xvf /tmp/containerd.tar.gz -C /usr/local/bin/ --strip-components=1


### PR DESCRIPTION


## Description
git is a prerequisite for the cloud-init script.
It's not present by default on every Cloud Provider Image.

## Motivation and Context

This fixes Issue #160. 
- [x] I have raised an issue to propose this change **this is required**


## How Has This Been Tested?
I created a faasd Server on Hetzner Cloud.


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Commits:

- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] My commit message has a body and describe how this was tested and why it is required.
- [x] I have signed-off my commits with `git commit -s` for the Developer Certificate of Origin (DCO)

Code:

- [ ] My code follows the code style of this project.
- [ ] I have added tests to cover my changes.

Docs:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
