### PR TITLE
Set the hostname for containers and functions

### DIFF
--- a/pkg/provider/handlers/deploy.go
+++ b/pkg/provider/handlers/deploy.go
@@ -147,6 +147,7 @@ func deploy(ctx context.Context, req types.FunctionDeployment, client *container
 		containerd.WithSnapshotter(snapshotter),
 		containerd.WithNewSnapshot(name+"-snapshot", image),
 		containerd.WithNewSpec(oci.WithImageConfig(image),
+			oci.WithHostname(name),
 			oci.WithCapabilities([]string{"CAP_NET_RAW"}),
 			oci.WithMounts(mounts),
 			oci.WithEnv(envs),

--- a/pkg/supervisor.go
+++ b/pkg/supervisor.go
@@ -172,6 +172,7 @@ func (s *Supervisor) Start(svcs []Service) error {
 			containerd.WithImage(image),
 			containerd.WithNewSnapshot(svc.Name+"-snapshot", image),
 			containerd.WithNewSpec(oci.WithImageConfig(image),
+				oci.WithHostname(svc.Name),
 				withUserOrDefault(svc.User),
 				oci.WithCapabilities(svc.Caps),
 				oci.WithMounts(mounts),


### PR DESCRIPTION
Signed-off-by: Alex Ellis (OpenFaaS Ltd) <alexellis2@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Set the hostname for containers and functions

## Motivation and Context

By setting the hostname, the container will resolve to its
name instead of just localhost.

## How Has This Been Tested?

CI, manual testing to follow

Before:

```
pi@faasd-pi:~ $ sudo ctr -n openfaas-fn  t exec --exec-id 2398  nodeinfo hostname
faasd-pi
```

After:

```
pi@k4s-1:~ $ sudo ctr -n openfaas-fn  t exec --exec-id 22954 nodeinfo hostname
nodeinfo
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
