### PR TITLE
Allow alternative runtimes for functions

### DIFF
--- a/pkg/cninetwork/cni_network.go
+++ b/pkg/cninetwork/cni_network.go
@@ -42,7 +42,7 @@ const (
 	defaultBridgeName = "openfaas0"
 
 	// defaultSubnet is the default subnet used in the defaultCNIConf -- this value is set to not collide with common container networking subnets:
-	defaultSubnet = "10.62.0.0/16"
+	defaultSubnet = "10.63.0.0/16"
 
 	// defaultIfPrefix is the interface name to be created in the container
 	defaultIfPrefix = "eth"
@@ -179,7 +179,7 @@ func GetIPAddress(container string, PID uint32) (string, error) {
 //
 // Example:
 //
-// /var/run/cni/openfaas-cni-bridge/10.62.0.2
+// /var/run/cni/openfaas-cni-bridge/10.63.0.2
 //
 // nats-621
 // eth1

--- a/pkg/cninetwork/cni_network_test.go
+++ b/pkg/cninetwork/cni_network_test.go
@@ -10,7 +10,7 @@ import (
 func Test_isCNIResultForPID_Found(t *testing.T) {
 	body := `nats-621
 eth1`
-	fileName := `10.62.0.2`
+	fileName := `10.63.0.2`
 	container := "nats"
 	PID := uint32(621)
 	fullPath := filepath.Join(os.TempDir(), fileName)
@@ -38,7 +38,7 @@ eth1`
 func Test_isCNIResultForPID_NoMatch(t *testing.T) {
 	body := `nats-621
 eth1`
-	fileName := `10.62.0.3`
+	fileName := `10.63.0.3`
 	container := "gateway"
 	PID := uint32(621)
 	fullPath := filepath.Join(os.TempDir(), fileName)

--- a/pkg/provider/handlers/deploy.go
+++ b/pkg/provider/handlers/deploy.go
@@ -148,6 +148,7 @@ func deploy(ctx context.Context, req types.FunctionDeployment, client *container
 			oci.WithCapabilities([]string{"CAP_NET_RAW"}),
 			oci.WithMounts(mounts),
 			oci.WithEnv(envs),
+			oci.WithLinuxDevice("/dev/kvm", "rmw"),
 			withMemory(memory)),
 		containerd.WithContainerLabels(labels)}
 


### PR DESCRIPTION
Signed-off-by: Alex Ellis (OpenFaaS Ltd) <alexellis2@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Allow alternative runtimes for functions

## Motivation and Context

By setting FUNCTION_RUNTIME, in theory an alternative container
runtime could be used such as libkrun or kata. In practice,
other changes are required like using the VM network.

## How Has This Been Tested?

Testing with: https://gist.github.com/alexellis/13ed0de2211e1ac9bd1cb5f8a7e19d47

Replace the binary downloaded for faasd with one you build yourself with `make dist` on a Linux `x86_64` host with Go 1.15/1.16 installed

## Types of changes

Temporary patch for testing.