### PR TITLE
Add pacman to the install script

### DIFF
--- a/hack/install.sh
+++ b/hack/install.sh
@@ -39,6 +39,10 @@ has_apt_get() {
   [ -n "$(command -v apt-get)" ]
 }
 
+has_pacman() {
+  [ -n "$(command -v pacman)" ]
+}
+
 install_required_packages() {
   if $(has_apt_get); then
     $SUDO apt-get update -y
@@ -46,8 +50,11 @@ install_required_packages() {
   elif $(has_yum); then
     $SUDO yum check-update -y
     $SUDO yum install -y curl runc
+  elif $(has_pacman); then
+    $SUDO pacman -Syy
+    $SUDO pacman -Sy curl runc bridge-utils
   else
-    fatal "Could not find apt-get or yum. Cannot install dependencies on this OS."
+    fatal "Could not find apt-get, yum, or pacman. Cannot install dependencies on this OS."
     exit 1
   fi
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Since I use Manjaro/Arch locally and wanted to setup faasd to play around with I noticed that the hack/install.sh script fails since it cannot find `yum` or `apt-get` on the system, and thus decided to include `pacman` as a third option.
## Description
<!--- Describe your changes in detail -->
I simply added another method that also checks for the presence of `pacman` and adds the commands you need for it to install the dependencies. It worked like a charm.
## Motivation and Context
This change makes it possible to use the automatic `install.sh` script on Linux distributions that use `pacman` as a package manager. This should allow a greater number of people to try out faasd in a convenient and easy manner, since I would guess a lot of first time users aren't comfortable editing installation scripts themselves to get it working on their distro.
Addresses [Issue 173](https://github.com/openfaas/faasd/issues/173)
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change **this is required**


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I've tested the changes on my local development machine running Manjaro. I ran the install.sh script with the modifications, and it worked perfectly and got OpenFaaS installed and running with faasd as a provider. 
```sh
uname -a
Linux jp-manjaro 5.11.6-1-MANJARO #1 SMP PREEMPT Thu Mar 11 19:05:51 UTC 2021 x86_64 GNU/Linux
```
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Commits:

- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] My commit message has a body and describe how this was tested and why it is required.
- [x] I have signed-off my commits with `git commit -s` for the Developer Certificate of Origin (DCO)

Code:

- [x] My code follows the code style of this project.
- [ ] I have added tests to cover my changes.
(Not really necessary since there aren't any Unit tests in this regard.)

Docs:

- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
(There is no specific documentation from what I've seen, but the error message was updated to include pacman accordingly.)