### PR TITLE
Make nameserver overridable for provider

### DIFF
--- a/cmd/provider.go
+++ b/cmd/provider.go
@@ -28,6 +28,7 @@ func makeProviderCmd() *cobra.Command {
 	}
 
 	command.Flags().String("pull-policy", "Always", `Set to "Always" to force a pull of images upon deployment, or "IfNotPresent" to try to use a cached image.`)
+	command.Flags().String("nameserver", "8.8.8.8", `Set to the DNS server you want to use for resolving DNS queries`)
 
 	command.RunE = func(_ *cobra.Command, _ []string) error {
 
@@ -39,6 +40,11 @@ func makeProviderCmd() *cobra.Command {
 		alwaysPull := false
 		if pullPolicy == "Always" {
 			alwaysPull = true
+		}
+
+		nameserver, flagErr := command.Flags().GetString("nameserver")
+		if flagErr != nil {
+			return flagErr
 		}
 
 		config, providerConfig, err := config.ReadFromEnv(types.OsEnv{})
@@ -62,7 +68,7 @@ func makeProviderCmd() *cobra.Command {
 		}
 
 		writeResolvErr := ioutil.WriteFile(path.Join(wd, "resolv.conf"),
-			[]byte(`nameserver 8.8.8.8`), workingDirectoryPermission)
+			[]byte(fmt.Sprintf("nameserver %s", nameserver)), workingDirectoryPermission)
 
 		if writeResolvErr != nil {
 			return fmt.Errorf("cannot write resolv.conf file: %s", writeResolvErr)


### PR DESCRIPTION
Adds a flag to the provider command that allows to override the default
nameserver in for example the systemd unit file for faasd-provider.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Added a single string flag to cmd/provider.go called `nameserver`.
That flag has a default value of `8.8.8.8` and will get used when `resolve.conf` created later in the source.


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [X] I have raised an issue to propose this change **this is required**

Will probably solve #174 and #176.
Edit: made my own issue #181

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I ran the test provided in the code.

Built a version of it and deployed to my raspberry pi instance of faasd.
Then I modified the unit file `/usr/lib/systemd/system/faasd-provider.service` and restarted everything.
```
[Unit]
Description=faasd-provider

[Service]
MemoryLimit=500M
Environment="secret_mount_path=/var/lib/faasd/secrets"
Environment="basic_auth=true"
ExecStart=/usr/local/bin/faasd provider --nameserver 172.16.10.252
Restart=on-failure
RestartSec=10s
WorkingDirectory=/var/lib/faasd-provider

[Install]
WantedBy=multi-user.target
```
Then I deployed a function that looked up a database server using a hostname that is only resolvable from the defined internal DNS and everything worked.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Commits:

- [X] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [X] My commit message has a body and describe how this was tested and why it is required.
- [X] I have signed-off my commits with `git commit -s` for the Developer Certificate of Origin (DCO)

Code:

- [X] My code follows the code style of this project.
- [ ] I have added tests to cover my changes.

Docs:

- [X] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
