### PR TITLE
[FIX] 2.2.1 version of caddy does not start with systemd on Ubuntu 18.04

### DIFF
--- a/hack/install.sh
+++ b/hack/install.sh
@@ -150,7 +150,7 @@ install_caddy() {
       ;;
     esac
 
-    curl -sSL "https://github.com/caddyserver/caddy/releases/download/v2.2.1/caddy_2.2.1_linux_${suffix}.tar.gz" | $SUDO tar -xvz -C /usr/bin/ caddy
+    curl -sSL "https://github.com/caddyserver/caddy/releases/download/v2.4.3/caddy_2.4.3_linux_${suffix}.tar.gz" | $SUDO tar -xvz -C /usr/bin/ caddy
     $SUDO curl -fSLs https://raw.githubusercontent.com/caddyserver/dist/master/init/caddy.service --output /etc/systemd/system/caddy.service
 
     $SUDO mkdir -p /etc/caddy


### PR DESCRIPTION
Updated to 2.4.3

Signed-off-by: Mark Sharpley <msh@Marks-MacBook-Pro.local>

<!--- Provide a general summary of your changes in the Title above -->

## Description
updated install.sh to use 2.4.1 version of caddy.

## Motivation and Context
Using this script with cloud init on Ubuntu 18.04. Systemd cannot start the service:
```bash
Jul 12 21:42:06 faasd caddy[3652]: {"level":"info","ts":1626126126.605867,"msg":"autosaved config","file":"/var/lib/caddy/.config/caddy/autosave.json"}
Jul 12 21:42:06 faasd caddy[3652]: {"level":"info","ts":1626126126.6060488,"msg":"serving initial configuration"}
Jul 12 21:43:36 faasd systemd[1]: caddy.service: Start operation timed out. Terminating.
Jul 12 21:43:36 faasd caddy[3652]: {"level":"info","ts":1626126216.6931598,"msg":"shutting down apps then terminating","signal":"SIGTERM"}
Jul 12 21:43:37 faasd caddy[3652]: {"level":"info","ts":1626126217.693724,"logger":"tls.cache.maintenance","msg":"stopped background certificate maintenance","cache":"0xc0002d41c0"}
Jul 12 21:43:38 faasd caddy[3652]: {"level":"info","ts":1626126218.1942427,"logger":"admin","msg":"stopped previous server"}
Jul 12 21:43:38 faasd caddy[3652]: {"level":"info","ts":1626126218.1942854,"msg":"shutdown done","signal":"SIGTERM"}
Jul 12 21:43:38 faasd systemd[1]: caddy.service: Failed with result 'timeout'.
Jul 12 21:43:38 faasd systemd[1]: Failed to start Caddy.
-- Subject: Unit caddy.service has failed
-- Defined-By: systemd
-- Support: http://www.ubuntu.com/support
--
-- Unit caddy.service has failed.
```

- [x ] I have raised an issue to propose this change
#184 

## How Has This Been Tested?
Tested manually:
```
ubuntu@faasd:~$ curl -sSL "https://github.com/caddyserver/caddy/releases/download/v2.4.3/caddy_2.4.3_linux_amd64.tar.gz" | sudo tar -xvz -C /usr/bin/ caddy
caddy

ubuntu@faasd:~$ sudo systemctl restart caddy
ubuntu@faasd:~$ sudo systemctl status caddy
● caddy.service - Caddy
   Loaded: loaded (/etc/systemd/system/caddy.service; enabled; vendor preset: enabled)
   Active: active (running) since Mon 2021-07-12 21:53:54 UTC; 4s ago
     Docs: https://caddyserver.com/docs/
 Main PID: 3883 (caddy)
    Tasks: 8 (limit: 1120)
   CGroup: /system.slice/caddy.service
           └─3883 /usr/bin/caddy run --environ --config /etc/caddy/Caddyfile

Jul 12 21:53:54 faasd caddy[3883]: {"level":"info","ts":1626126834.9049375,"logger":"admin","msg":"admin endpoint started","address":"tcp/localhost:2019","enforce_origin":f
alse,"origins":["localhost:2019","[::1]:2019","127.0.0.1:2019"]}
Jul 12 21:53:54 faasd caddy[3883]: {"level":"info","ts":1626126834.9053664,"logger":"tls.cache.maintenance","msg":"started background certificate maintenance","cache":"0xc0
00264d20"}
Jul 12 21:53:54 faasd caddy[3883]: {"level":"info","ts":1626126834.9054606,"logger":"http","msg":"server is listening only on the HTTPS port but has no TLS connection polic
ies; adding one to enable TLS","server_name":"srv0","https_port":443}
Jul 12 21:53:54 faasd caddy[3883]: {"level":"info","ts":1626126834.9055247,"logger":"http","msg":"enabling automatic HTTP->HTTPS redirects","server_name":"srv0"}
Jul 12 21:53:54 faasd caddy[3883]: {"level":"info","ts":1626126834.9059358,"logger":"http","msg":"enabling automatic TLS certificate management","domains":["faasd.sharpley.
xyz"]}
Jul 12 21:53:54 faasd caddy[3883]: {"level":"info","ts":1626126834.9072638,"logger":"tls","msg":"cleaning storage unit","description":"FileStorage:/var/lib/caddy/.local/sha
re/caddy"}
Jul 12 21:53:54 faasd caddy[3883]: {"level":"info","ts":1626126834.9124532,"logger":"tls","msg":"finished cleaning storage units"}
Jul 12 21:53:54 faasd caddy[3883]: {"level":"info","ts":1626126834.994078,"msg":"autosaved config (load with --resume flag)","file":"/var/lib/caddy/.config/caddy/autosave.j
son"}
Jul 12 21:53:54 faasd caddy[3883]: {"level":"info","ts":1626126834.994325,"msg":"serving initial configuration"}
Jul 12 21:53:54 faasd systemd[1]: Started Caddy.
```

Also used my fork of faasd which includes the new version of caddy to bootstrap the instance: 

ubuntu@faasd:~$ systemctl status caddy
● caddy.service - Caddy
   Loaded: loaded (/etc/systemd/system/caddy.service; enabled; vendor preset: enabled)
   Active: active (running) since Mon 2021-07-12 22:34:53 UTC; 30min ago
     Docs: https://caddyserver.com/docs/
 Main PID: 2813 (caddy)
    Tasks: 8 (limit: 1120)
   CGroup: /system.slice/caddy.service
           └─2813 /usr/bin/caddy run --environ --config /etc/caddy/Caddyfile



## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Commits:

- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] My commit message has a body and describe how this was tested and why it is required.
- [x] I have signed-off my commits with `git commit -s` for the Developer Certificate of Origin (DCO)

Code:

- [x] My code follows the code style of this project.
- [x] I have added tests to cover my changes.

Docs:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
