### PR TITLE
Enable multi namespace support

### DIFF
--- a/pkg/constants.go
+++ b/pkg/constants.go
@@ -4,8 +4,8 @@ const (
 	// FunctionNamespace is the default containerd namespace functions are created
 	FunctionNamespace = "openfaas-fn"
 
-	// faasdNamespace is the containerd namespace services are created
-	faasdNamespace = "openfaas"
+	// FaasdNamespace is the containerd namespace services are created
+	FaasdNamespace = "openfaas"
 
 	faasServicesPullAlways = false
 

--- a/pkg/provider/handlers/functions_test.go
+++ b/pkg/provider/handlers/functions_test.go
@@ -2,9 +2,10 @@ package handlers
 
 import (
 	"fmt"
-	"github.com/opencontainers/runtime-spec/specs-go"
 	"reflect"
 	"testing"
+
+	"github.com/opencontainers/runtime-spec/specs-go"
 )
 
 func Test_BuildLabelsAndAnnotationsFromServiceSpec_Annotations(t *testing.T) {
@@ -80,6 +81,28 @@ func Test_ProcessEnvToEnvVars(t *testing.T) {
 			if fprocess != tc.fprocess {
 				t.Fatalf("expected fprocess: %s, got: %s", tc.fprocess, got)
 
+			}
+		})
+	}
+}
+
+func Test_findNamespace(t *testing.T) {
+	type test struct {
+		Name            string
+		foundNamespaces []string
+		namespace       string
+		Expected        bool
+	}
+	tests := []test{
+		{Name: "Namespace Found", namespace: "fn", foundNamespaces: []string{"fn", "openfaas-fn"}, Expected: true},
+		{Name: "namespace Not Found", namespace: "fn", foundNamespaces: []string{"openfaas-fn"}, Expected: false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.Name, func(t *testing.T) {
+			got := findNamespace(tc.namespace, tc.foundNamespaces)
+			if got != tc.Expected {
+				t.Fatalf("expected %t, got %t", tc.Expected, got)
 			}
 		})
 	}

--- a/pkg/provider/handlers/namespaces.go
+++ b/pkg/provider/handlers/namespaces.go
@@ -1,0 +1,18 @@
+package handlers
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/containerd/containerd"
+)
+
+func MakeNamespacesLister(client *containerd.Client) func(w http.ResponseWriter, r *http.Request) {
+	return func(w http.ResponseWriter, r *http.Request) {
+		list := ListNamespaces(client)
+		body, _ := json.Marshal(list)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.Write(body)
+	}
+}

--- a/pkg/provider/handlers/read.go
+++ b/pkg/provider/handlers/read.go
@@ -13,8 +13,10 @@ func MakeReadHandler(client *containerd.Client) func(w http.ResponseWriter, r *h
 
 	return func(w http.ResponseWriter, r *http.Request) {
 
+		lookupNamespace := getRequestNamespace(readNamespaceFromQuery(r))
+
 		res := []types.FunctionStatus{}
-		fns, err := ListFunctions(client)
+		fns, err := ListFunctions(client, lookupNamespace)
 		if err != nil {
 			log.Printf("[Read] error listing functions. Error: %s\n", err)
 			http.Error(w, err.Error(), http.StatusBadRequest)

--- a/pkg/provider/handlers/replicas.go
+++ b/pkg/provider/handlers/replicas.go
@@ -14,8 +14,9 @@ func MakeReplicaReaderHandler(client *containerd.Client) func(w http.ResponseWri
 	return func(w http.ResponseWriter, r *http.Request) {
 		vars := mux.Vars(r)
 		functionName := vars["name"]
+		lookupNamespace := getRequestNamespace(readNamespaceFromQuery(r))
 
-		if f, err := GetFunction(client, functionName); err == nil {
+		if f, err := GetFunction(client, functionName, lookupNamespace); err == nil {
 			found := types.FunctionStatus{
 				Name:              functionName,
 				AvailableReplicas: uint64(f.replicas),

--- a/pkg/provider/handlers/utils.go
+++ b/pkg/provider/handlers/utils.go
@@ -1,0 +1,25 @@
+package handlers
+
+import (
+	"net/http"
+	"path"
+
+	faasd "github.com/openfaas/faasd/pkg"
+)
+
+func getRequestNamespace(namespace string) string {
+
+	if len(namespace) > 0 {
+		return namespace
+	}
+	return faasd.FunctionNamespace
+}
+
+func readNamespaceFromQuery(r *http.Request) string {
+	q := r.URL.Query()
+	return q.Get("namespace")
+}
+
+func getNamespaceSecretMountPath(userSecretPath string, namespace string) string {
+	return path.Join(userSecretPath, namespace)
+}

--- a/pkg/provider/handlers/utils_test.go
+++ b/pkg/provider/handlers/utils_test.go
@@ -1,0 +1,75 @@
+package handlers
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	faasd "github.com/openfaas/faasd/pkg"
+)
+
+func Test_getRequestNamespace(t *testing.T) {
+	tables := []struct {
+		name              string
+		requestNamespace  string
+		expectedNamespace string
+	}{
+		{name: "RequestNamespace is not provided", requestNamespace: "", expectedNamespace: faasd.FunctionNamespace},
+		{name: "RequestNamespace is provided", requestNamespace: "user-namespace", expectedNamespace: "user-namespace"},
+	}
+
+	for _, tc := range tables {
+		t.Run(tc.name, func(t *testing.T) {
+			actualNamespace := getRequestNamespace(tc.requestNamespace)
+			if actualNamespace != tc.expectedNamespace {
+				t.Errorf("Got: %s, expected %s", actualNamespace, tc.expectedNamespace)
+			}
+		})
+	}
+}
+
+func Test_getNamespaceSecretMountPath(t *testing.T) {
+	userSecretPath := "/var/openfaas/secrets"
+	tables := []struct {
+		name               string
+		requestNamespace   string
+		expectedSecretPath string
+	}{
+		{name: "Default Namespace is provided", requestNamespace: faasd.FunctionNamespace, expectedSecretPath: "/var/openfaas/secrets/" + faasd.FunctionNamespace},
+		{name: "User Namespace is provided", requestNamespace: "user-namespace", expectedSecretPath: "/var/openfaas/secrets/user-namespace"},
+	}
+
+	for _, tc := range tables {
+		t.Run(tc.name, func(t *testing.T) {
+			actualNamespace := getNamespaceSecretMountPath(userSecretPath, tc.requestNamespace)
+			if actualNamespace != tc.expectedSecretPath {
+				t.Errorf("Got: %s, expected %s", actualNamespace, tc.expectedSecretPath)
+			}
+		})
+	}
+}
+
+func Test_readNamespaceFromQuery(t *testing.T) {
+	tables := []struct {
+		name              string
+		queryNamespace    string
+		expectedNamespace string
+	}{
+		{name: "No Namespace is provided", queryNamespace: "", expectedNamespace: ""},
+		{name: "User Namespace is provided", queryNamespace: "user-namespace", expectedNamespace: "user-namespace"},
+	}
+
+	for _, tc := range tables {
+		t.Run(tc.name, func(t *testing.T) {
+
+			url := fmt.Sprintf("/test?namespace=%s", tc.queryNamespace)
+			r := httptest.NewRequest(http.MethodGet, url, nil)
+
+			actualNamespace := readNamespaceFromQuery(r)
+			if actualNamespace != tc.expectedNamespace {
+				t.Errorf("Got: %s, expected %s", actualNamespace, tc.expectedNamespace)
+			}
+		})
+	}
+}

--- a/pkg/supervisor.go
+++ b/pkg/supervisor.go
@@ -79,7 +79,7 @@ func NewSupervisor(sock string) (*Supervisor, error) {
 }
 
 func (s *Supervisor) Start(svcs []Service) error {
-	ctx := namespaces.WithNamespace(context.Background(), faasdNamespace)
+	ctx := namespaces.WithNamespace(context.Background(), FaasdNamespace)
 
 	wd, _ := os.Getwd()
 
@@ -243,7 +243,7 @@ func (s *Supervisor) Close() {
 }
 
 func (s *Supervisor) Remove(svcs []Service) error {
-	ctx := namespaces.WithNamespace(context.Background(), faasdNamespace)
+	ctx := namespaces.WithNamespace(context.Background(), FaasdNamespace)
 
 	for _, svc := range svcs {
 		err := cninetwork.DeleteCNINetwork(ctx, s.cni, s.client, svc.Name)


### PR DESCRIPTION
Signed-off-by: Nitishkumar Singh <nitishkumarsingh71@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Provide support of multiple namespaces into faasd
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change **this is required**

Closes #195
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
1. Run Test `make test`
2. Build Binary `make dist`
3. Prepare environment `make prepare-test`
4. Test E2E `make test-e2e`
5. Use certifer to test the new binary
```
export TEST_FUNCTIONS = \
	stronghash \
	env-test \
	env-test-annotations \
	env-test-labels \
	env-test-verbs \
	test-secret-crud \
	test-min-scale \
	test-scale-from-zero \
	test-throughput-scaling \
	test-scaling-disabled \
	test-scaling-to-zero \
	test-logger \
	redirector-test

export TEST_SECRETS=secret-name

go mod download
export CI=true
export OPENFAAS_CONFIG='~/.openfaas'
export OPENFAAS_URL='http://127.0.0.1:8080/'    
export CERTIFIER_NAMESPACES=certifier-test 
export FEATURE_FLAGS='-enableAuth'
time go test -count=1 ./tests -v -gateway=${OPENFAAS_URL} ${FEATURE_FLAGS}
```

The above commands produces output the below output. Majority of test related invoke, deploy, list were successful. Some of them related to scaling and logs were failed.

```
2021/08/12 00:47:58 {
	"Gateway": "http://127.0.0.1:8080",
	"Auth": {},
	"Client": {
		"ClientAuth": {},
		"GatewayURL": {
			"Scheme": "http",
			"Opaque": "",
			"User": null,
			"Host": "127.0.0.1:8080",
			"Path": "",
			"RawPath": "",
			"ForceQuery": false,
			"RawQuery": "",
			"Fragment": "",
			"RawFragment": ""
		},
		"UserAgent": ""
	},
	"AuthEnabled": true,
	"SecretUpdate": true,
	"ScaleToZero": true,
	"Namespaces": [
		"certifier-test"
	],
	"DefaultNamespace": "openfaas-fn"
}
=== RUN   Test_Deploy_MetaData
=== RUN   Test_Deploy_MetaData/Deploy_without_any_extra_metadata
=== RUN   Test_Deploy_MetaData/Deploy_with_labels
=== RUN   Test_Deploy_MetaData/Deploy_with_annotations
=== RUN   Test_Deploy_MetaData/Deploy_without_any_extra_metadata_to_certifier-test
=== RUN   Test_Deploy_MetaData/Deploy_with_labels_to_certifier-test
=== RUN   Test_Deploy_MetaData/Deploy_with_annotations_to_certifier-test
=== RUN   Test_Deploy_MetaData/test_listing_functions
    deploy_test.go:145: got docker.io/functions/alpine:latest, expected image functions/alpine:latest
--- FAIL: Test_Deploy_MetaData (7.77s)
    --- PASS: Test_Deploy_MetaData/Deploy_without_any_extra_metadata (2.47s)
    --- PASS: Test_Deploy_MetaData/Deploy_with_labels (1.05s)
    --- PASS: Test_Deploy_MetaData/Deploy_with_annotations (1.04s)
    --- PASS: Test_Deploy_MetaData/Deploy_without_any_extra_metadata_to_certifier-test (1.01s)
    --- PASS: Test_Deploy_MetaData/Deploy_with_labels_to_certifier-test (1.03s)
    --- PASS: Test_Deploy_MetaData/Deploy_with_annotations_to_certifier-test (1.16s)
    --- FAIL: Test_Deploy_MetaData/test_listing_functions (0.01s)
=== RUN   Test_ListNamespaces
--- PASS: Test_ListNamespaces (0.00s)
=== RUN   Test_HealthEndpoint
--- PASS: Test_HealthEndpoint (0.00s)
=== RUN   Test_ProviderInfo
--- PASS: Test_ProviderInfo (0.00s)
=== RUN   Test_InvokeNotFound
    invoke_test.go:19: [1/30] Got correct response: 404 - http://127.0.0.1:8080/function/.openfaas-fn
--- PASS: Test_InvokeNotFound (0.04s)
=== RUN   Test_Invoke
=== RUN   Test_Invoke/Invoke_test_with_different_verbs
=== RUN   Test_Invoke/Invoke_test_with_different_verbs/GET
    invoke_test.go:37: [1/30] Got correct response: 200 - http://127.0.0.1:8080/function/env-test-verbs.openfaas-fn
=== RUN   Test_Invoke/Invoke_test_with_different_verbs/POST
    invoke_test.go:37: [1/30] Got correct response: 200 - http://127.0.0.1:8080/function/env-test-verbs.openfaas-fn
=== RUN   Test_Invoke/Invoke_test_with_different_verbs/PUT
    invoke_test.go:37: [1/30] Got correct response: 200 - http://127.0.0.1:8080/function/env-test-verbs.openfaas-fn
=== RUN   Test_Invoke/Invoke_test_with_different_verbs/PATCH
    invoke_test.go:37: [1/30] Got correct response: 200 - http://127.0.0.1:8080/function/env-test-verbs.openfaas-fn
=== RUN   Test_Invoke/Invoke_test_with_different_verbs/DELETE
    invoke_test.go:37: [1/30] Got correct response: 200 - http://127.0.0.1:8080/function/env-test-verbs.openfaas-fn
=== RUN   Test_Invoke/Invoke_propogates_redirect_to_the_caller
    invoke_test.go:126: [1/30] Got correct response: 302 - http://127.0.0.1:8080/function/redirector-test.openfaas-fn
=== RUN   Test_Invoke/Invoke_with_custom_env_vars_and_query_string
=== RUN   Test_Invoke/Invoke_with_custom_env_vars_and_query_string/Empty_QueryString
    invoke_test.go:59: [1/30] Got correct response: 200 - http://127.0.0.1:8080/function/env-test.openfaas-fn
=== RUN   Test_Invoke/Invoke_with_custom_env_vars_and_query_string/Populated_QueryString
    invoke_test.go:67: [1/30] Got correct response: 200 - http://127.0.0.1:8080/function/env-test.openfaas-fn?testing=1
=== RUN   Test_Invoke/Invoke_test_with_different_verbs_to_certifier-test
=== RUN   Test_Invoke/Invoke_test_with_different_verbs_to_certifier-test/GET
    invoke_test.go:37: [1/30] Got correct response: 200 - http://127.0.0.1:8080/function/env-test-verbs.certifier-test
=== RUN   Test_Invoke/Invoke_test_with_different_verbs_to_certifier-test/POST
    invoke_test.go:37: [1/30] Got correct response: 200 - http://127.0.0.1:8080/function/env-test-verbs.certifier-test
=== RUN   Test_Invoke/Invoke_test_with_different_verbs_to_certifier-test/PUT
    invoke_test.go:37: [1/30] Got correct response: 200 - http://127.0.0.1:8080/function/env-test-verbs.certifier-test
=== RUN   Test_Invoke/Invoke_test_with_different_verbs_to_certifier-test/PATCH
    invoke_test.go:37: [1/30] Got correct response: 200 - http://127.0.0.1:8080/function/env-test-verbs.certifier-test
=== RUN   Test_Invoke/Invoke_test_with_different_verbs_to_certifier-test/DELETE
    invoke_test.go:37: [1/30] Got correct response: 200 - http://127.0.0.1:8080/function/env-test-verbs.certifier-test
=== RUN   Test_Invoke/Invoke_propogates_redirect_to_the_caller_to_certifier-test
    invoke_test.go:126: [1/30] Got correct response: 302 - http://127.0.0.1:8080/function/redirector-test.certifier-test
=== RUN   Test_Invoke/Invoke_with_custom_env_vars_and_query_string_to_certifier-test
=== RUN   Test_Invoke/Invoke_with_custom_env_vars_and_query_string_to_certifier-test/Empty_QueryString
    invoke_test.go:59: [1/30] Got correct response: 200 - http://127.0.0.1:8080/function/env-test.certifier-test
=== RUN   Test_Invoke/Invoke_with_custom_env_vars_and_query_string_to_certifier-test/Populated_QueryString
    invoke_test.go:67: [1/30] Got correct response: 200 - http://127.0.0.1:8080/function/env-test.certifier-test?testing=1
--- PASS: Test_Invoke (7.12s)
    --- PASS: Test_Invoke/Invoke_test_with_different_verbs (1.41s)
        --- PASS: Test_Invoke/Invoke_test_with_different_verbs/GET (0.11s)
        --- PASS: Test_Invoke/Invoke_test_with_different_verbs/POST (0.01s)
        --- PASS: Test_Invoke/Invoke_test_with_different_verbs/PUT (0.01s)
        --- PASS: Test_Invoke/Invoke_test_with_different_verbs/PATCH (0.01s)
        --- PASS: Test_Invoke/Invoke_test_with_different_verbs/DELETE (0.01s)
    --- PASS: Test_Invoke/Invoke_propogates_redirect_to_the_caller (1.17s)
    --- PASS: Test_Invoke/Invoke_with_custom_env_vars_and_query_string (1.13s)
        --- PASS: Test_Invoke/Invoke_with_custom_env_vars_and_query_string/Empty_QueryString (0.03s)
        --- PASS: Test_Invoke/Invoke_with_custom_env_vars_and_query_string/Populated_QueryString (0.01s)
    --- PASS: Test_Invoke/Invoke_test_with_different_verbs_to_certifier-test (1.16s)
        --- PASS: Test_Invoke/Invoke_test_with_different_verbs_to_certifier-test/GET (0.08s)
        --- PASS: Test_Invoke/Invoke_test_with_different_verbs_to_certifier-test/POST (0.01s)
        --- PASS: Test_Invoke/Invoke_test_with_different_verbs_to_certifier-test/PUT (0.01s)
        --- PASS: Test_Invoke/Invoke_test_with_different_verbs_to_certifier-test/PATCH (0.01s)
        --- PASS: Test_Invoke/Invoke_test_with_different_verbs_to_certifier-test/DELETE (0.01s)
    --- PASS: Test_Invoke/Invoke_propogates_redirect_to_the_caller_to_certifier-test (1.10s)
    --- PASS: Test_Invoke/Invoke_with_custom_env_vars_and_query_string_to_certifier-test (1.14s)
        --- PASS: Test_Invoke/Invoke_with_custom_env_vars_and_query_string_to_certifier-test/Empty_QueryString (0.03s)
        --- PASS: Test_Invoke/Invoke_with_custom_env_vars_and_query_string_to_certifier-test/Populated_QueryString (0.01s)
=== RUN   Test_FunctionLogs
=== RUN   Test_FunctionLogs/0_provider_can_stream_logs_from_openfaas-fn
    logs_test.go:75: [1/30] Got correct response: 200 - http://127.0.0.1:8080/function/test-logger.openfaas-fn
    logs_test.go:124: got unexpected log message "Version: 0.18.8\tSHA: 76e463a7a017f81ed88ae7824d2ef7a3f60ed45e", expected "Forking fprocess"
=== RUN   Test_FunctionLogs/1_provider_can_stream_logs_from_certifier-test
    logs_test.go:75: [1/30] Got correct response: 200 - http://127.0.0.1:8080/function/test-logger.certifier-test
    logs_test.go:124: got unexpected log message "Version: 0.18.8\tSHA: 76e463a7a017f81ed88ae7824d2ef7a3f60ed45e", expected "Forking fprocess"
--- FAIL: Test_FunctionLogs (2.48s)
    --- FAIL: Test_FunctionLogs/0_provider_can_stream_logs_from_openfaas-fn (1.22s)
    --- FAIL: Test_FunctionLogs/1_provider_can_stream_logs_from_certifier-test (1.26s)
=== RUN   Test_ScaleMinimum
    scaling_test.go:41: got 1 replicas, wanted 2
Error removing existing function: Delete "http://127.0.0.1:8080/system/functions?namespace=openfaas-fn": context deadline exceeded (Client.Timeout exceeded while awaiting headers), gateway=http://127.0.0.1:8080, functionName=test-min-scale
    panic.go:617: Delete "http://127.0.0.1:8080/system/functions?namespace=openfaas-fn": context deadline exceeded (Client.Timeout exceeded while awaiting headers)
--- FAIL: Test_ScaleMinimum (6.04s)
=== RUN   Test_ScaleFromZeroDuringInvoke
    scaling_test.go:47: scale to zero currently returns 500 in faas-swarm
--- SKIP: Test_ScaleFromZeroDuringInvoke (0.00s)
=== RUN   Test_ScaleUpAndDownFromThroughPut
    scaling_test.go:123: function load output 
        Summary:
          Total:	100.0203 secs
          Slowest:	0.1959 secs
          Fastest:	0.0080 secs
          Average:	0.0462 secs
          Requests/sec:	9.9980
          
          Total data:	132000 bytes
          Size/request:	132 bytes
        
        Response time histogram:
          0.008 [1]	|
          0.027 [496]	|■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■
          0.046 [137]	|■■■■■■■■■■■
          0.064 [107]	|■■■■■■■■■
          0.083 [73]	|■■■■■■
          0.102 [85]	|■■■■■■■
          0.121 [61]	|■■■■■
          0.140 [23]	|■■
          0.158 [5]	|
          0.177 [6]	|
          0.196 [6]	|
        
        
        Latency distribution:
          10% in 0.0166 secs
          25% in 0.0195 secs
          50% in 0.0281 secs
          75% in 0.0666 secs
          90% in 0.1022 secs
          95% in 0.1178 secs
          99% in 0.1638 secs
        
        Details (average, fastest, slowest):
          DNS+dialup:	0.0004 secs, 0.0080 secs, 0.1959 secs
          DNS-lookup:	0.0000 secs, 0.0000 secs, 0.0000 secs
          req write:	0.0002 secs, 0.0000 secs, 0.0030 secs
          resp wait:	0.0454 secs, 0.0077 secs, 0.1953 secs
          resp read:	0.0001 secs, 0.0000 secs, 0.0006 secs
        
        Status code distribution:
          [200]	1000 responses
        
        
        
    scaling_test.go:124: never reached max scale 2, only 1 replicas after 1000 attempts
Error removing existing function: Delete "http://127.0.0.1:8080/system/functions?namespace=openfaas-fn": context deadline exceeded (Client.Timeout exceeded while awaiting headers), gateway=http://127.0.0.1:8080, functionName=test-throughput-scaling
    panic.go:617: Delete "http://127.0.0.1:8080/system/functions?namespace=openfaas-fn": context deadline exceeded (Client.Timeout exceeded while awaiting headers)
--- FAIL: Test_ScaleUpAndDownFromThroughPut (107.85s)
=== RUN   Test_ScalingDisabledViaLabels
    scaling_test.go:185: function load output 
        Summary:
          Total:	100.0185 secs
          Slowest:	0.2122 secs
          Fastest:	0.0074 secs
          Average:	0.0440 secs
          Requests/sec:	9.9982
          
          Total data:	132000 bytes
          Size/request:	132 bytes
        
        Response time histogram:
          0.007 [1]	|
          0.028 [512]	|■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■
          0.048 [145]	|■■■■■■■■■■■
          0.069 [100]	|■■■■■■■■
          0.089 [106]	|■■■■■■■■
          0.110 [72]	|■■■■■■
          0.130 [50]	|■■■■
          0.151 [8]	|■
          0.171 [4]	|
          0.192 [0]	|
          0.212 [2]	|
        
        
        Latency distribution:
          10% in 0.0151 secs
          25% in 0.0177 secs
          50% in 0.0264 secs
          75% in 0.0671 secs
          90% in 0.0983 secs
          95% in 0.1139 secs
          99% in 0.1475 secs
        
        Details (average, fastest, slowest):
          DNS+dialup:	0.0004 secs, 0.0074 secs, 0.2122 secs
          DNS-lookup:	0.0000 secs, 0.0000 secs, 0.0000 secs
          req write:	0.0002 secs, 0.0000 secs, 0.0013 secs
          resp wait:	0.0432 secs, 0.0071 secs, 0.2113 secs
          resp read:	0.0001 secs, 0.0000 secs, 0.0006 secs
        
        Status code distribution:
          [200]	1000 responses
        
        
        
    scaling_test.go:186: unexpected scaling, expected 2, got 1 replicas after 1000 attempts
Error removing existing function: Delete "http://127.0.0.1:8080/system/functions?namespace=openfaas-fn": context deadline exceeded (Client.Timeout exceeded while awaiting headers), gateway=http://127.0.0.1:8080, functionName=test-scaling-disabled
    panic.go:617: Delete "http://127.0.0.1:8080/system/functions?namespace=openfaas-fn": context deadline exceeded (Client.Timeout exceeded while awaiting headers)
--- FAIL: Test_ScalingDisabledViaLabels (107.83s)
=== RUN   Test_ScaleToZero
    scaling_test.go:203: set 'idler_enabled' to test scale to zero
--- SKIP: Test_ScaleToZero (0.00s)
=== RUN   Test_SecretCRUD
    secretCRUD_test.go:21: got 200, wanted 200 or 202
--- FAIL: Test_SecretCRUD (0.03s)
FAIL
FAIL	github.com/openfaas/certifier/tests	239.164s
FAIL

real	4m0.357s
user	0m1.757s
sys	0m0.733s
```


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Commits:

- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] My commit message has a body and describe how this was tested and why it is required.
- [x] I have signed-off my commits with `git commit -s` for the Developer Certificate of Origin (DCO)

Code:

- [x] My code follows the code style of this project.
- [x] I have added tests to cover my changes.

Docs:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
