### PR TITLE
Fix for migration to 0.14.0 and #201

### DIFF
--- a/cmd/install.go
+++ b/cmd/install.go
@@ -109,7 +109,16 @@ func binExists(folder, name string) error {
 	}
 	return nil
 }
+func ensureSecretsDir(folder string) error {
+	if _, err := os.Stat(folder); err != nil {
+		err = os.MkdirAll(folder, secretDirPermission)
+		if err != nil {
+			return err
+		}
+	}
 
+	return nil
+}
 func ensureWorkingDir(folder string) error {
 	if _, err := os.Stat(folder); err != nil {
 		err = os.MkdirAll(folder, workingDirectoryPermission)

--- a/pkg/provider/handlers/functions.go
+++ b/pkg/provider/handlers/functions.go
@@ -72,7 +72,7 @@ func GetFunction(client *containerd.Client, name string, namespace string) (Func
 	allLabels, labelErr := c.Labels(ctx)
 
 	if labelErr != nil {
-		log.Printf("cannot list container %s labels: %w", containerName, labelErr)
+		log.Printf("cannot list container %s labels: %s", containerName, labelErr)
 	}
 
 	labels, annotations := buildLabelsAndAnnotations(allLabels)


### PR DESCRIPTION
Signed-off-by: Alex Ellis (OpenFaaS Ltd) <alexellis2@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Fix for migration to 0.14.0 and #201

## Motivation and Context

Fixes #201 

Old secrets are now copied, rather than moved, so that any
existing functions do not need to be redeployed by the user.

As a maintenance task, users should remove the older secrets.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

TBD

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
