### PR TITLE
Add check for namespace label openfaas=true

### DIFF
--- a/pkg/provider/handlers/delete.go
+++ b/pkg/provider/handlers/delete.go
@@ -42,6 +42,18 @@ func MakeDeleteHandler(client *containerd.Client, cni gocni.CNI) func(w http.Res
 
 		lookupNamespace := getRequestNamespace(readNamespaceFromQuery(r))
 
+		// Check if namespace exists, and it has the openfaas label
+		nsValid, err := validateNamespace(client, lookupNamespace)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+
+		if !nsValid {
+			http.Error(w, "namespace not valid", http.StatusBadRequest)
+			return
+		}
+
 		name := req.FunctionName
 
 		function, err := GetFunction(client, name, lookupNamespace)

--- a/pkg/provider/handlers/deploy.go
+++ b/pkg/provider/handlers/deploy.go
@@ -52,10 +52,25 @@ func MakeDeployHandler(client *containerd.Client, cni gocni.CNI, secretMountPath
 		}
 
 		namespace := getRequestNamespace(req.Namespace)
+
+		// Check if namespace exists, and it has the openfaas label
+		nsValid, err := validateNamespace(client, namespace)
+
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+
+		if !nsValid {
+			http.Error(w, "namespace not valid", http.StatusBadRequest)
+			return
+		}
+
 		namespaceSecretMountPath := getNamespaceSecretMountPath(secretMountPath, namespace)
 		err = validateSecrets(namespaceSecretMountPath, req.Secrets)
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
 		}
 
 		name := req.Service

--- a/pkg/provider/handlers/functions.go
+++ b/pkg/provider/handlers/functions.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log"
 	"strings"
@@ -32,6 +33,17 @@ type Function struct {
 
 // ListFunctions returns a map of all functions with running tasks on namespace
 func ListFunctions(client *containerd.Client, namespace string) (map[string]*Function, error) {
+
+	// Check if namespace exists, and it has the openfaas label
+	nsValid, err := validateNamespace(client, namespace)
+	if err != nil {
+		return nil, err
+	}
+
+	if !nsValid {
+		return nil, errors.New("namespace not valid")
+	}
+
 	ctx := namespaces.WithNamespace(context.Background(), namespace)
 	functions := make(map[string]*Function)
 

--- a/pkg/provider/handlers/read.go
+++ b/pkg/provider/handlers/read.go
@@ -14,6 +14,17 @@ func MakeReadHandler(client *containerd.Client) func(w http.ResponseWriter, r *h
 	return func(w http.ResponseWriter, r *http.Request) {
 
 		lookupNamespace := getRequestNamespace(readNamespaceFromQuery(r))
+		// Check if namespace exists, and it has the openfaas label
+		nsValid, err := validateNamespace(client, lookupNamespace)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+
+		if !nsValid {
+			http.Error(w, "namespace not valid", http.StatusBadRequest)
+			return
+		}
 
 		res := []types.FunctionStatus{}
 		fns, err := ListFunctions(client, lookupNamespace)

--- a/pkg/provider/handlers/replicas.go
+++ b/pkg/provider/handlers/replicas.go
@@ -16,6 +16,18 @@ func MakeReplicaReaderHandler(client *containerd.Client) func(w http.ResponseWri
 		functionName := vars["name"]
 		lookupNamespace := getRequestNamespace(readNamespaceFromQuery(r))
 
+		// Check if namespace exists, and it has the openfaas label
+		nsValid, err := validateNamespace(client, lookupNamespace)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+
+		if !nsValid {
+			http.Error(w, "namespace not valid", http.StatusBadRequest)
+			return
+		}
+
 		if f, err := GetFunction(client, functionName, lookupNamespace); err == nil {
 			found := types.FunctionStatus{
 				Name:              functionName,

--- a/pkg/provider/handlers/scale.go
+++ b/pkg/provider/handlers/scale.go
@@ -41,6 +41,18 @@ func MakeReplicaUpdateHandler(client *containerd.Client, cni gocni.CNI) func(w h
 
 		namespace := getRequestNamespace(readNamespaceFromQuery(r))
 
+		// Check if namespace exists, and it has the openfaas label
+		nsValid, err := validateNamespace(client, namespace)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+
+		if !nsValid {
+			http.Error(w, "namespace not valid", http.StatusBadRequest)
+			return
+		}
+
 		name := req.ServiceName
 
 		if _, err := GetFunction(client, name, namespace); err != nil {

--- a/pkg/provider/handlers/secret.go
+++ b/pkg/provider/handlers/secret.go
@@ -49,6 +49,18 @@ func MakeSecretHandler(c *containerd.Client, mountPath string) func(w http.Respo
 func listSecrets(c *containerd.Client, w http.ResponseWriter, r *http.Request, mountPath string) {
 
 	lookupNamespace := getRequestNamespace(readNamespaceFromQuery(r))
+	// Check if namespace exists, and it has the openfaas label
+	nsValid, err := validateNamespace(c, lookupNamespace)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	if !nsValid {
+		http.Error(w, "namespace not valid", http.StatusBadRequest)
+		return
+	}
+
 	mountPath = getNamespaceSecretMountPath(mountPath, lookupNamespace)
 
 	files, err := ioutil.ReadDir(mountPath)

--- a/pkg/provider/handlers/update.go
+++ b/pkg/provider/handlers/update.go
@@ -41,6 +41,19 @@ func MakeUpdateHandler(client *containerd.Client, cni gocni.CNI, secretMountPath
 		}
 		name := req.Service
 		namespace := getRequestNamespace(req.Namespace)
+
+		// Check if namespace exists, and it has the openfaas label
+		nsValid, err := validateNamespace(client, namespace)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+
+		if !nsValid {
+			http.Error(w, "namespace not valid", http.StatusBadRequest)
+			return
+		}
+
 		namespaceSecretMountPath := getNamespaceSecretMountPath(secretMountPath, namespace)
 
 		function, err := GetFunction(client, name, namespace)


### PR DESCRIPTION
This commit adds the checks that the namespace supplied by the user has
the `openfaas=true` label. Without this check the user can
deploy/update/read functions in any namespace  using the CLI.

The UI is not effected because it calls the listnamesaces endpoint,
which has the check for the label

Signed-off-by: Alistair Hey <alistair@heyal.co.uk>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change **this is required**
closes #203 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
deployed the modified faasd to multipass and tried to:

create a fn in non-existing ns (failed)
create a fn in a ns that exists, but no label (failed)
delete a fn in a ns that has a fn deployed (was labeled, label removed) (failed)
list fns in a non-labeled ns (failed)

deploy to a labeled ns (worked)
delete from a labeled ns (worked)
list fns in a labeled ns (worked)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Commits:

- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] My commit message has a body and describe how this was tested and why it is required.
- [x] I have signed-off my commits with `git commit -s` for the Developer Certificate of Origin (DCO)

Code:

- [x] My code follows the code style of this project.
- [ ] I have added tests to cover my changes.

Docs:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
