### PR TITLE
Daft: Extend docker resolver in service, to use plain HTTP if enabled.

### DIFF
--- a/cmd/provider.go
+++ b/cmd/provider.go
@@ -32,6 +32,8 @@ func makeProviderCmd() *cobra.Command {
 
 	command.Flags().String("pull-policy", "Always", `Set to "Always" to force a pull of images upon deployment, or "IfNotPresent" to try to use a cached image.`)
 
+	// command.Flags().Bool("--insecure-registry", false, `Set to true to allow to pull images from a non HTTPS image registry.`)
+
 	command.RunE = func(_ *cobra.Command, _ []string) error {
 
 		pullPolicy, flagErr := command.Flags().GetString("pull-policy")


### PR DESCRIPTION
Signed-off-by: Shikachuu <zcmate@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->
Add plain HTTP support without TLS for container registries.
## Description
**Currently this PR is heavily work in progress, I created it this early to have an open discuission for the implementation.** 

The current plan is:
- Provide a CLI flag (currently named: `--insecure-registry`) to enable this feature
- Let you use plain HTTP when you pull images
- Disables TLS verification when using HTTP

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [ ] I have raised an issue to propose this change **this is required**
- [X] Issue #186 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Commits:

- [X] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [] My commit message has a body and describe how this was tested and why it is required.
- [X] I have signed-off my commits with `git commit -s` for the Developer Certificate of Origin (DCO)

Code:

- [X] My code follows the code style of this project.
- [ ] I have added tests to cover my changes.

Docs:

- [X] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
