### PR TITLE
Populate the memory limits of functions in the REST API

### DIFF
--- a/pkg/provider/handlers/functions.go
+++ b/pkg/provider/handlers/functions.go
@@ -93,7 +93,7 @@ func GetFunction(client *containerd.Client, name string, namespace string) (Func
 
 	spec, err := c.Spec(ctx)
 	if err != nil {
-		return Function{}, fmt.Errorf("unable to load function spec for reading secrets and limits: %s, error %w", name, err)
+		return Function{}, fmt.Errorf("unable to load function %s error: %w", name, err)
 	}
 
 	info, err := c.Info(ctx)
@@ -235,16 +235,7 @@ func findNamespace(target string, items []string) bool {
 }
 
 func readMemoryLimitFromSpec(spec *specs.Spec) int64 {
-	if spec.Linux != nil {
-		return 0
-	}
-	if spec.Linux.Resources == nil {
-		return 0
-	}
-	if spec.Linux.Resources.Memory == nil {
-		return 0
-	}
-	if spec.Linux.Resources.Memory.Limit == nil {
+	if spec.Linux == nil || spec.Linux.Resources == nil || spec.Linux.Resources.Memory == nil || spec.Linux.Resources.Memory.Limit == nil {
 		return 0
 	}
 	return *spec.Linux.Resources.Memory.Limit

--- a/pkg/provider/handlers/functions.go
+++ b/pkg/provider/handlers/functions.go
@@ -29,6 +29,7 @@ type Function struct {
 	secrets     []string
 	envVars     map[string]string
 	envProcess  string
+	memoryLimit int64
 	createdAt   time.Time
 }
 
@@ -112,6 +113,7 @@ func GetFunction(client *containerd.Client, name string, namespace string) (Func
 	fn.envVars = envVars
 	fn.envProcess = envProcess
 	fn.createdAt = info.CreatedAt
+	fn.memoryLimit = *spec.Linux.Resources.Memory.Limit
 
 	replicas := 0
 	task, err := c.Task(ctx, nil)

--- a/pkg/provider/handlers/functions_test.go
+++ b/pkg/provider/handlers/functions_test.go
@@ -32,54 +32,54 @@ func Test_BuildLabelsAndAnnotationsFromServiceSpec_Annotations(t *testing.T) {
 }
 
 func Test_SplitMountToSecrets(t *testing.T) {
-	type test struct {
-		Name     string
-		Input    []specs.Mount
-		Expected []string
+	type testCase struct {
+		Name  string
+		Input []specs.Mount
+		Want  []string
 	}
-	tests := []test{
-		{Name: "No matching openfaas secrets", Input: []specs.Mount{{Destination: "/foo/"}}, Expected: []string{}},
-		{Name: "Nil mounts", Input: nil, Expected: []string{}},
-		{Name: "No Mounts", Input: []specs.Mount{{Destination: "/foo/"}}, Expected: []string{}},
-		{Name: "One Mounts IS secret", Input: []specs.Mount{{Destination: "/var/openfaas/secrets/secret1"}}, Expected: []string{"secret1"}},
-		{Name: "Multiple Mounts 1 secret", Input: []specs.Mount{{Destination: "/var/openfaas/secrets/secret1"}, {Destination: "/some/other/path"}}, Expected: []string{"secret1"}},
-		{Name: "Multiple Mounts all secrets", Input: []specs.Mount{{Destination: "/var/openfaas/secrets/secret1"}, {Destination: "/var/openfaas/secrets/secret2"}}, Expected: []string{"secret1", "secret2"}},
+	tests := []testCase{
+		{Name: "No matching openfaas secrets", Input: []specs.Mount{{Destination: "/foo/"}}, Want: []string{}},
+		{Name: "Nil mounts", Input: nil, Want: []string{}},
+		{Name: "No Mounts", Input: []specs.Mount{{Destination: "/foo/"}}, Want: []string{}},
+		{Name: "One Mounts IS secret", Input: []specs.Mount{{Destination: "/var/openfaas/secrets/secret1"}}, Want: []string{"secret1"}},
+		{Name: "Multiple Mounts 1 secret", Input: []specs.Mount{{Destination: "/var/openfaas/secrets/secret1"}, {Destination: "/some/other/path"}}, Want: []string{"secret1"}},
+		{Name: "Multiple Mounts all secrets", Input: []specs.Mount{{Destination: "/var/openfaas/secrets/secret1"}, {Destination: "/var/openfaas/secrets/secret2"}}, Want: []string{"secret1", "secret2"}},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.Name, func(t *testing.T) {
 			got := readSecretsFromMounts(tc.Input)
-			if !reflect.DeepEqual(got, tc.Expected) {
-				t.Fatalf("expected %s, got %s", tc.Expected, got)
+			if !reflect.DeepEqual(got, tc.Want) {
+				t.Fatalf("Want %s, got %s", tc.Want, got)
 			}
 		})
 	}
 }
 
 func Test_ProcessEnvToEnvVars(t *testing.T) {
-	type test struct {
+	type testCase struct {
 		Name     string
 		Input    []string
-		Expected map[string]string
+		Want     map[string]string
 		fprocess string
 	}
-	tests := []test{
-		{Name: "No matching EnvVars", Input: []string{"PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin", "fprocess=python index.py"}, Expected: make(map[string]string), fprocess: "python index.py"},
-		{Name: "No EnvVars", Input: []string{}, Expected: make(map[string]string), fprocess: ""},
-		{Name: "One EnvVar", Input: []string{"PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin", "fprocess=python index.py", "env=this"}, Expected: map[string]string{"env": "this"}, fprocess: "python index.py"},
-		{Name: "Multiple EnvVars", Input: []string{"PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin", "this=that", "env=var", "fprocess=python index.py"}, Expected: map[string]string{"this": "that", "env": "var"}, fprocess: "python index.py"},
-		{Name: "Nil EnvVars", Input: nil, Expected: make(map[string]string)},
+	tests := []testCase{
+		{Name: "No matching EnvVars", Input: []string{"PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin", "fprocess=python index.py"}, Want: make(map[string]string), fprocess: "python index.py"},
+		{Name: "No EnvVars", Input: []string{}, Want: make(map[string]string), fprocess: ""},
+		{Name: "One EnvVar", Input: []string{"PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin", "fprocess=python index.py", "env=this"}, Want: map[string]string{"env": "this"}, fprocess: "python index.py"},
+		{Name: "Multiple EnvVars", Input: []string{"PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin", "this=that", "env=var", "fprocess=python index.py"}, Want: map[string]string{"this": "that", "env": "var"}, fprocess: "python index.py"},
+		{Name: "Nil EnvVars", Input: nil, Want: make(map[string]string)},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.Name, func(t *testing.T) {
 			got, fprocess := readEnvFromProcessEnv(tc.Input)
-			if !reflect.DeepEqual(got, tc.Expected) {
-				t.Fatalf("expected: %s, got: %s", tc.Expected, got)
+			if !reflect.DeepEqual(got, tc.Want) {
+				t.Fatalf("Want: %s, got: %s", tc.Want, got)
 			}
 
 			if fprocess != tc.fprocess {
-				t.Fatalf("expected fprocess: %s, got: %s", tc.fprocess, got)
+				t.Fatalf("Want fprocess: %s, got: %s", tc.fprocess, got)
 
 			}
 		})
@@ -87,46 +87,46 @@ func Test_ProcessEnvToEnvVars(t *testing.T) {
 }
 
 func Test_findNamespace(t *testing.T) {
-	type test struct {
+	type testCase struct {
 		Name            string
 		foundNamespaces []string
 		namespace       string
-		Expected        bool
+		Want            bool
 	}
-	tests := []test{
-		{Name: "Namespace Found", namespace: "fn", foundNamespaces: []string{"fn", "openfaas-fn"}, Expected: true},
-		{Name: "namespace Not Found", namespace: "fn", foundNamespaces: []string{"openfaas-fn"}, Expected: false},
+	tests := []testCase{
+		{Name: "Namespace Found", namespace: "fn", foundNamespaces: []string{"fn", "openfaas-fn"}, Want: true},
+		{Name: "namespace Not Found", namespace: "fn", foundNamespaces: []string{"openfaas-fn"}, Want: false},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.Name, func(t *testing.T) {
 			got := findNamespace(tc.namespace, tc.foundNamespaces)
-			if got != tc.Expected {
-				t.Fatalf("expected %t, got %t", tc.Expected, got)
+			if got != tc.Want {
+				t.Fatalf("Want %t, got %t", tc.Want, got)
 			}
 		})
 	}
 }
 
 func Test_readMemoryLimitFromSpec(t *testing.T) {
-	type test struct {
-		Name     string
-		Spec     *specs.Spec
-		Expected int64
+	type testCase struct {
+		Name string
+		Spec *specs.Spec
+		Want int64
 	}
 	testLimit := int64(64)
-	tests := []test{
-		{Name: "specs.Linux not found", Spec: &specs.Spec{Linux: nil}, Expected: int64(0)},
-		{Name: "specs.LinuxResource not found", Spec: &specs.Spec{Linux: &specs.Linux{Resources: nil}}, Expected: int64(0)},
-		{Name: "specs.LinuxMemory not found", Spec: &specs.Spec{Linux: &specs.Linux{Resources: &specs.LinuxResources{Memory: nil}}}, Expected: int64(0)},
-		{Name: "specs.LinuxMemory.Limit not found", Spec: &specs.Spec{Linux: &specs.Linux{Resources: &specs.LinuxResources{Memory: &specs.LinuxMemory{Limit: nil}}}}, Expected: int64(0)},
-		{Name: "Memory limit set as expected", Spec: &specs.Spec{Linux: &specs.Linux{Resources: &specs.LinuxResources{Memory: &specs.LinuxMemory{Limit: &testLimit}}}}, Expected: int64(64)},
+	tests := []testCase{
+		{Name: "specs.Linux not found", Spec: &specs.Spec{Linux: nil}, Want: int64(0)},
+		{Name: "specs.LinuxResource not found", Spec: &specs.Spec{Linux: &specs.Linux{Resources: nil}}, Want: int64(0)},
+		{Name: "specs.LinuxMemory not found", Spec: &specs.Spec{Linux: &specs.Linux{Resources: &specs.LinuxResources{Memory: nil}}}, Want: int64(0)},
+		{Name: "specs.LinuxMemory.Limit not found", Spec: &specs.Spec{Linux: &specs.Linux{Resources: &specs.LinuxResources{Memory: &specs.LinuxMemory{Limit: nil}}}}, Want: int64(0)},
+		{Name: "Memory limit set as Want", Spec: &specs.Spec{Linux: &specs.Linux{Resources: &specs.LinuxResources{Memory: &specs.LinuxMemory{Limit: &testLimit}}}}, Want: int64(64)},
 	}
 	for _, tc := range tests {
 		t.Run(tc.Name, func(t *testing.T) {
 			got := readMemoryLimitFromSpec(tc.Spec)
-			if got != tc.Expected {
-				t.Fatalf("expected %d, got %d", tc.Expected, got)
+			if got != tc.Want {
+				t.Fatalf("Want %d, got %d", tc.Want, got)
 			}
 		})
 	}

--- a/pkg/provider/handlers/functions_test.go
+++ b/pkg/provider/handlers/functions_test.go
@@ -107,3 +107,27 @@ func Test_findNamespace(t *testing.T) {
 		})
 	}
 }
+
+func Test_readMemoryLimitFromSpec(t *testing.T) {
+	type test struct {
+		Name     string
+		Spec     *specs.Spec
+		Expected int64
+	}
+	testLimit := int64(64)
+	tests := []test{
+		{Name: "specs.Linux not found", Spec: &specs.Spec{Linux: nil}, Expected: int64(0)},
+		{Name: "specs.LinuxResource not found", Spec: &specs.Spec{Linux: &specs.Linux{Resources: nil}}, Expected: int64(0)},
+		{Name: "specs.LinuxMemory not found", Spec: &specs.Spec{Linux: &specs.Linux{Resources: &specs.LinuxResources{Memory: nil}}}, Expected: int64(0)},
+		{Name: "specs.LinuxMemory.Limit not found", Spec: &specs.Spec{Linux: &specs.Linux{Resources: &specs.LinuxResources{Memory: &specs.LinuxMemory{Limit: nil}}}}, Expected: int64(0)},
+		{Name: "Memory limit set as expected", Spec: &specs.Spec{Linux: &specs.Linux{Resources: &specs.LinuxResources{Memory: &specs.LinuxMemory{Limit: &testLimit}}}}, Expected: int64(64)},
+	}
+	for _, tc := range tests {
+		t.Run(tc.Name, func(t *testing.T) {
+			got := readMemoryLimitFromSpec(tc.Spec)
+			if got != tc.Expected {
+				t.Fatalf("expected %d, got %d", tc.Expected, got)
+			}
+		})
+	}
+}

--- a/pkg/provider/handlers/read.go
+++ b/pkg/provider/handlers/read.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"encoding/json"
+	"k8s.io/apimachinery/pkg/api/resource"
 	"log"
 	"net/http"
 
@@ -37,6 +38,7 @@ func MakeReadHandler(client *containerd.Client) func(w http.ResponseWriter, r *h
 		for _, fn := range fns {
 			annotations := &fn.annotations
 			labels := &fn.labels
+			memory := resource.NewQuantity(fn.memoryLimit, resource.BinarySI)
 			res = append(res, types.FunctionStatus{
 				Name:        fn.name,
 				Image:       fn.image,
@@ -47,6 +49,7 @@ func MakeReadHandler(client *containerd.Client) func(w http.ResponseWriter, r *h
 				Secrets:     fn.secrets,
 				EnvVars:     fn.envVars,
 				EnvProcess:  fn.envProcess,
+				Limits:      &types.FunctionResources{Memory: memory.String()},
 				CreatedAt:   fn.createdAt,
 			})
 		}

--- a/pkg/provider/handlers/read.go
+++ b/pkg/provider/handlers/read.go
@@ -38,7 +38,7 @@ func MakeReadHandler(client *containerd.Client) func(w http.ResponseWriter, r *h
 		for _, fn := range fns {
 			annotations := &fn.annotations
 			labels := &fn.labels
-			memory := resource.NewQuantity(fn.memoryLimit, resource.BinarySI)
+			memory := resource.NewQuantity(fn.memoryLimit, resource.DecimalSI)
 			res = append(res, types.FunctionStatus{
 				Name:        fn.name,
 				Image:       fn.image,
@@ -49,7 +49,7 @@ func MakeReadHandler(client *containerd.Client) func(w http.ResponseWriter, r *h
 				Secrets:     fn.secrets,
 				EnvVars:     fn.envVars,
 				EnvProcess:  fn.envProcess,
-				Limits:      &types.FunctionResources{Memory: memory.String()},
+				Limits:      &types.FunctionResources{Memory: memory.ToDec().String()},
 				CreatedAt:   fn.createdAt,
 			})
 		}

--- a/pkg/provider/handlers/read.go
+++ b/pkg/provider/handlers/read.go
@@ -38,7 +38,7 @@ func MakeReadHandler(client *containerd.Client) func(w http.ResponseWriter, r *h
 		for _, fn := range fns {
 			annotations := &fn.annotations
 			labels := &fn.labels
-			memory := resource.NewQuantity(fn.memoryLimit, resource.DecimalSI)
+			memory := resource.NewQuantity(fn.memoryLimit, resource.BinarySI)
 			res = append(res, types.FunctionStatus{
 				Name:        fn.name,
 				Image:       fn.image,
@@ -49,7 +49,7 @@ func MakeReadHandler(client *containerd.Client) func(w http.ResponseWriter, r *h
 				Secrets:     fn.secrets,
 				EnvVars:     fn.envVars,
 				EnvProcess:  fn.envProcess,
-				Limits:      &types.FunctionResources{Memory: memory.ToDec().String()},
+				Limits:      &types.FunctionResources{Memory: memory.String()},
 				CreatedAt:   fn.createdAt,
 			})
 		}


### PR DESCRIPTION
Signed-off-by: Shikachuu <zcmate@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
Add memory limits to the response json file, if you query functions through the API.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [ ] I have raised an issue to propose this change **this is required**
- [X] Issue #177


## How Has This Been Tested?
1. take an existing faasd deployment (a vm for example)
2. stop the faasd and the faasd-provider service with systemctl
`sudo systemctl stop faasd faasd-provider`
3. copile the faasd binary from my fork (in my case i used the amd64 arch)
`make dist`
4. replace `/usr/local/bin/faasd` with the one that we compiled in the previous step
`sudo mv bin/faasd /usr/local/bin/faasd`
5. chown /usr/local/bin/faasd to root
`sudo chown root /usr/local/bin/faasd`
6. start the faasd and the faasd-provider services with systemctl
`sudo systemctl start faasd faasd-provider`
7. get your faasd API password
`FAASDPW=$(sudo cat /var/lib/faasd/secrets/basic-auth-password ; echo)`
8. deploy the following function with `faas-cli deploy -f ./fn.yml`
```yaml
verison: 1.0
provider:
  name: openfaas
  gateway: http://localhost:8080
functions:
  figlet:
    skip_build: true
    image: ghcr.io/openfaas/figlet:latest
    limits:
      memory: 20M
```
9. do a get request with curl to the gateway API and pipe it to `jq` to see the result
`curl -s http://admin:$FAASDPW@localhost:8080/system/functions | jq`
Example output:
```json
{
  "name": "figlet",
  "image": "ghcr.io/openfaas/figlet:latest",
  "namespace": "openfaas-fn",
  "envProcess": "figlet",
  "envVars": {
    "write_debug": "false"
  },
  "labels": {},
  "annotations": {},
  "limits": {
    "memory": "20M"
  },
  "invocationCount": 1,
  "replicas": 1,
  "createdAt": "2021-09-20T20:03:18.117439332Z"
}
```
Or you can query just for the limits object: `curl -s http://admin:$FAASDPW@localhost:8080/system/functions | jq .[0].limits`
Example output:
```json
{
  "memory": "20M"
}
```
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Commits:

- [X] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [X] My commit message has a body and describe how this was tested and why it is required.
- [X] I have signed-off my commits with `git commit -s` for the Developer Certificate of Origin (DCO)

Code:

- [X] My code follows the code style of this project.
- [x] I have added tests to cover my changes.

Docs:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
