### PR TITLE
chore: improve multipass cloud-config and instructions

### DIFF
--- a/cloud-config.txt
+++ b/cloud-config.txt
@@ -10,17 +10,7 @@ packages:
  - git
 
 runcmd:
-- curl -sLSf https://github.com/containerd/containerd/releases/download/v1.5.4/containerd-1.5.4-linux-amd64.tar.gz > /tmp/containerd.tar.gz && tar -xvf /tmp/containerd.tar.gz -C /usr/local/bin/ --strip-components=1
-- curl -SLfs https://raw.githubusercontent.com/containerd/containerd/v1.5.4/containerd.service | tee /etc/systemd/system/containerd.service
-- systemctl daemon-reload && systemctl start containerd
-- systemctl enable containerd
-- /sbin/sysctl -w net.ipv4.conf.all.forwarding=1
-- mkdir -p /opt/cni/bin
-- curl -sSL https://github.com/containernetworking/plugins/releases/download/v0.8.5/cni-plugins-linux-amd64-v0.8.5.tgz | tar -xz -C /opt/cni/bin
-- mkdir -p /go/src/github.com/openfaas/
-- cd /go/src/github.com/openfaas/ && git clone --depth 1 --branch 0.13.0 https://github.com/openfaas/faasd
-- curl -fSLs "https://github.com/openfaas/faasd/releases/download/0.13.0/faasd" --output "/usr/local/bin/faasd" && chmod a+x "/usr/local/bin/faasd"
-- cd /go/src/github.com/openfaas/faasd/ && /usr/local/bin/faasd install
+- curl -sfL https://raw.githubusercontent.com/openfaas/faasd/master/hack/install.sh | sh -s -
 - systemctl status -l containerd --no-pager
 - journalctl -u faasd-provider --no-pager
 - systemctl status -l faasd-provider --no-pager

--- a/docs/MULTIPASS.md
+++ b/docs/MULTIPASS.md
@@ -27,111 +27,112 @@ It took me about 2-3 minutes to run through everything after installing multipas
 
 * Get my cloud-config.txt file
 
-```sh
-curl -sSLO https://raw.githubusercontent.com/openfaas/faasd/master/cloud-config.txt
-```
+    ```sh
+    curl -sSLO https://raw.githubusercontent.com/openfaas/faasd/master/cloud-config.txt
+    ```
 
-* Update the SSH key to match your own, edit `cloud-config.txt`:
+* Boot the VM 
 
-Replace the 2nd line with the contents of `~/.ssh/id_rsa.pub`:
+    The `cloud-config.txt` contains an ssh key to allow your local machine to access the VM. However, this must be updated with your local ssh key. 
+    This command will update the key with your local public key value and start the VM.
 
-```
-ssh_authorized_keys:
-  - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC8Q/aUYUr3P1XKVucnO9mlWxOjJm+K01lHJR90MkHC9zbfTqlp8P7C3J26zKAuzHXOeF+VFxETRr6YedQKW9zp5oP7sN+F2gr/pO7GV3VmOqHMV7uKfyUQfq7H1aVzLfCcI7FwN2Zekv3yB7kj35pbsMa1Za58aF6oHRctZU6UWgXXbRxP+B04DoVU7jTstQ4GMoOCaqYhgPHyjEAS3DW0kkPW6HzsvJHkxvVcVlZ/wNJa1Ie/yGpzOzWIN0Ol0t2QT/RSWOhfzO1A2P0XbPuZ04NmriBonO9zR7T1fMNmmtTuK7WazKjQT3inmYRAqU6pe8wfX8WIWNV7OowUjUsv alex@alexr.local
-```
+    ```sh
+    sed "s/ssh-rsa.*/$(cat $HOME/.ssh/id_*.pub)/" cloud-config.txt | multipass launch --name faasd --cloud-init -
+    ```
 
-* Boot the VM
+    This can also be done manually, just replace the 2nd line of the `cloud-config.txt` with the coPntents of your public ssh key, usually either `~/.ssh/id_rsa.pub` or `~/.ssh/id_ed25519.pub`
 
-```sh
-multipass launch --cloud-init cloud-config.txt  --name faasd
-```
+    ```
+    ssh_authorized_keys:
+      - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC8Q/aUYUr3P1XKVucnO9mlWxOjJm+K01lHJR90MkHC9zbfTqlp8P7C3J26zKAuzHXOeF+VFxETRr6YedQKW9zp5oP7sN+F2gr/pO7GV3VmOqHMV7uKfyUQfq7H1aVzLfCcI7FwN2Zekv3yB7kj35pbsMa1Za58aF6oHRctZU6UWgXXbRxP+B04DoVU7jTstQ4GMoOCaqYhgPHyjEAS3DW0kkPW6HzsvJHkxvVcVlZ/wNJa1Ie/yGpzOzWIN0Ol0t2QT/RSWOhfzO1A2P0XbPuZ04NmriBonO9zR7T1fMNmmtTuK7WazKjQT3inmYRAqU6pe8wfX8WIWNV7OowUjUsv alex@alexr.local
+    ```
 
 * Get the VM's IP and connect with `ssh`
 
-```sh
-multipass info faasd
-Name:           faasd
-State:          Running
-IPv4:           192.168.64.14
-Release:        Ubuntu 18.04.3 LTS
-Image hash:     a720c34066dc (Ubuntu 18.04 LTS)
-Load:           0.79 0.19 0.06
-Disk usage:     1.1G out of 4.7G
-Memory usage:   145.6M out of 985.7M
-```
+    ```sh
+    multipass info faasd
+    Name:           faasd
+    State:          Running
+    IPv4:           192.168.64.14
+    Release:        Ubuntu 18.04.3 LTS
+    Image hash:     a720c34066dc (Ubuntu 18.04 LTS)
+    Load:           0.79 0.19 0.06
+    Disk usage:     1.1G out of 4.7G
+    Memory usage:   145.6M out of 985.7M
+    ```
 
-Set the variable `IP`:
+    Set the variable `IP`:
 
-```
-export IP="192.168.64.14"
-```
+    ```
+    export IP="192.168.64.14"
+    ```
 
-You can also try to use `jq` to get the IP into a variable:
+    You can also try to use `jq` to get the IP into a variable:
 
-```sh
-export IP=$(multipass info faasd --format json| jq -r '.info.faasd.ipv4[0]')
-```
+    ```sh
+    export IP=$(multipass info faasd --format json| jq -r '.info.faasd.ipv4[0]')
+    ```
 
-Connect to the IP listed:
+    Connect to the IP listed:
 
-```sh
-ssh ubuntu@$IP
-```
+    ```sh
+    ssh ubuntu@$IP
+    ```
 
-Log out once you know it works.
+    Log out once you know it works.
 
 * Let's capture the authentication password into a file for use with `faas-cli`
 
-```
-ssh ubuntu@$IP "sudo cat /var/lib/faasd/secrets/basic-auth-password" > basic-auth-password
-```
+    ```
+    ssh ubuntu@$IP "sudo cat /var/lib/faasd/secrets/basic-auth-password" > basic-auth-password
+    ```
 
 ## Try faasd (OpenFaaS)
 
 * Login from your laptop (the host)
 
-```
-export OPENFAAS_URL=http://$IP:8080
-cat basic-auth-password | faas-cli login -s
-```
+    ```
+    export OPENFAAS_URL=http://$IP:8080
+    cat basic-auth-password | faas-cli login -s
+    ```
 
 * Deploy a function and invoke it
 
-```
-faas-cli store deploy figlet --env write_timeout=1s
-echo "faasd" | faas-cli invoke figlet
+    ```
+    faas-cli store deploy figlet --env write_timeout=1s
+    echo "faasd" | faas-cli invoke figlet
 
-faas-cli describe figlet
+    faas-cli describe figlet
 
-# Run async
-curl -i -d "faasd-async" $OPENFAAS_URL/async-function/figlet
+    # Run async
+    curl -i -d "faasd-async" $OPENFAAS_URL/async-function/figlet
 
-# Run async with a callback
+    # Run async with a callback
 
-curl -i -d "faasd-async" -H "X-Callback-Url: http://some-request-bin.com/path" $OPENFAAS_URL/async-function/figlet
-```
+    curl -i -d "faasd-async" -H "X-Callback-Url: http://some-request-bin.com/path" $OPENFAAS_URL/async-function/figlet
+    ```
 
-You can also checkout the other store functions: `faas-cli store list`
+    You can also checkout the other store functions: `faas-cli store list`
 
 * Try the UI
 
-Head over to the UI from your laptop and remember that your password is in the `basic-auth-password` file. The username is `admin`:
+    Head over to the UI from your laptop and remember that your password is in the `basic-auth-password` file. The username is `admin`:
 
-```
-echo http://$IP:8080
-```
+    ```
+    echo http://$IP:8080
+    ```
 
 * Stop/start the instance
 
-```sh
-multipass stop faasd
-```
+    ```sh
+    multipass stop faasd
+    ```
 
 * Delete, if you want to:
 
-```
-multipass delete --purge faasd
-```
+    ```
+    multipass delete --purge faasd
+    ```
 
 You now have a faasd appliance on your Mac. You can also use this cloud-init file with public cloud like AWS or DigitalOcean.
 


### PR DESCRIPTION
Improve the Multipass cloud-config.txt by using the install.sh script
instead of stale install instructions. This ensures that the latest
release is installed and reduces the number of install instructions we
need to maintain.

Also, improve the instructions for using multipass by including a
one-line command for setting the correct ssh key _and_ starting the VM.

Finally, improve the markdown formatting by indenting the paragraph
bodies of the list items. This ensures that the content is properly
aligned with the bullet list.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [ ] I have raised an issue to propose this change **this is required**

I was starting faasd locally to test the certifier and noticed that it was installing a stale version of faasd, v0.13.0. I found these new instructions a bit easier to follow.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

I have run this locally and been able to install and invoke functions inside the multipass VM


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Commits:

- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] My commit message has a body and describe how this was tested and why it is required.
- [x] I have signed-off my commits with `git commit -s` for the Developer Certificate of Origin (DCO)

Code:

- [x] My code follows the code style of this project.
- [ ] I have added tests to cover my changes.

Docs:

- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
