### PR TITLE
Handled list secrets for no secret in namespaces

### DIFF
--- a/cmd/provider.go
+++ b/cmd/provider.go
@@ -103,7 +103,7 @@ func makeProviderCmd() *cobra.Command {
 			HealthHandler:        func(w http.ResponseWriter, r *http.Request) {},
 			InfoHandler:          handlers.MakeInfoHandler(Version, GitCommit),
 			ListNamespaceHandler: handlers.MakeNamespacesLister(client),
-			SecretHandler:        handlers.MakeSecretHandler(client, baseUserSecretsPath),
+			SecretHandler:        handlers.MakeSecretHandler(client.NamespaceService(), baseUserSecretsPath),
 			LogHandler:           logs.NewLogHandlerFunc(faasdlogs.New(), config.ReadTimeout),
 		}
 

--- a/pkg/provider/handlers/delete.go
+++ b/pkg/provider/handlers/delete.go
@@ -43,7 +43,7 @@ func MakeDeleteHandler(client *containerd.Client, cni gocni.CNI) func(w http.Res
 		lookupNamespace := getRequestNamespace(readNamespaceFromQuery(r))
 
 		// Check if namespace exists, and it has the openfaas label
-		valid, err := validNamespace(client, lookupNamespace)
+		valid, err := validNamespace(client.NamespaceService(), lookupNamespace)
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusBadRequest)
 			return

--- a/pkg/provider/handlers/deploy.go
+++ b/pkg/provider/handlers/deploy.go
@@ -54,7 +54,7 @@ func MakeDeployHandler(client *containerd.Client, cni gocni.CNI, secretMountPath
 		namespace := getRequestNamespace(req.Namespace)
 
 		// Check if namespace exists, and it has the openfaas label
-		valid, err := validNamespace(client, namespace)
+		valid, err := validNamespace(client.NamespaceService(), namespace)
 
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusBadRequest)

--- a/pkg/provider/handlers/functions.go
+++ b/pkg/provider/handlers/functions.go
@@ -37,7 +37,7 @@ type Function struct {
 func ListFunctions(client *containerd.Client, namespace string) (map[string]*Function, error) {
 
 	// Check if namespace exists, and it has the openfaas label
-	valid, err := validNamespace(client, namespace)
+	valid, err := validNamespace(client.NamespaceService(), namespace)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/provider/handlers/read.go
+++ b/pkg/provider/handlers/read.go
@@ -2,9 +2,10 @@ package handlers
 
 import (
 	"encoding/json"
-	"k8s.io/apimachinery/pkg/api/resource"
 	"log"
 	"net/http"
+
+	"k8s.io/apimachinery/pkg/api/resource"
 
 	"github.com/containerd/containerd"
 	"github.com/openfaas/faas-provider/types"
@@ -16,7 +17,7 @@ func MakeReadHandler(client *containerd.Client) func(w http.ResponseWriter, r *h
 
 		lookupNamespace := getRequestNamespace(readNamespaceFromQuery(r))
 		// Check if namespace exists, and it has the openfaas label
-		valid, err := validNamespace(client, lookupNamespace)
+		valid, err := validNamespace(client.NamespaceService(), lookupNamespace)
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusBadRequest)
 			return

--- a/pkg/provider/handlers/replicas.go
+++ b/pkg/provider/handlers/replicas.go
@@ -17,7 +17,7 @@ func MakeReplicaReaderHandler(client *containerd.Client) func(w http.ResponseWri
 		lookupNamespace := getRequestNamespace(readNamespaceFromQuery(r))
 
 		// Check if namespace exists, and it has the openfaas label
-		valid, err := validNamespace(client, lookupNamespace)
+		valid, err := validNamespace(client.NamespaceService(), lookupNamespace)
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusBadRequest)
 			return

--- a/pkg/provider/handlers/scale.go
+++ b/pkg/provider/handlers/scale.go
@@ -42,7 +42,7 @@ func MakeReplicaUpdateHandler(client *containerd.Client, cni gocni.CNI) func(w h
 		namespace := getRequestNamespace(readNamespaceFromQuery(r))
 
 		// Check if namespace exists, and it has the openfaas label
-		valid, err := validNamespace(client, namespace)
+		valid, err := validNamespace(client.NamespaceService(), namespace)
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusBadRequest)
 			return

--- a/pkg/provider/handlers/update.go
+++ b/pkg/provider/handlers/update.go
@@ -43,7 +43,7 @@ func MakeUpdateHandler(client *containerd.Client, cni gocni.CNI, secretMountPath
 		namespace := getRequestNamespace(req.Namespace)
 
 		// Check if namespace exists, and it has the openfaas label
-		valid, err := validNamespace(client, namespace)
+		valid, err := validNamespace(client.NamespaceService(), namespace)
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusBadRequest)
 			return

--- a/pkg/provider/handlers/utils.go
+++ b/pkg/provider/handlers/utils.go
@@ -5,10 +5,9 @@ import (
 	"net/http"
 	"path"
 
-	"github.com/containerd/containerd"
-
 	"github.com/openfaas/faasd/pkg"
 	faasd "github.com/openfaas/faasd/pkg"
+	provider "github.com/openfaas/faasd/pkg/provider"
 )
 
 func getRequestNamespace(namespace string) string {
@@ -30,12 +29,11 @@ func getNamespaceSecretMountPath(userSecretPath string, namespace string) string
 
 // validNamespace indicates whether the namespace is eligable to be
 // used for OpenFaaS functions.
-func validNamespace(client *containerd.Client, namespace string) (bool, error) {
+func validNamespace(store provider.Labeller, namespace string) (bool, error) {
 	if namespace == faasd.DefaultFunctionNamespace {
 		return true, nil
 	}
 
-	store := client.NamespaceService()
 	labels, err := store.Labels(context.Background(), namespace)
 	if err != nil {
 		return false, err

--- a/pkg/provider/labeller.go
+++ b/pkg/provider/labeller.go
@@ -1,0 +1,18 @@
+package provider
+
+import "context"
+
+type Labeller interface {
+	Labels(ctx context.Context, namespace string) (map[string]string, error)
+}
+
+/*
+ * FakeLabeller can be used to fake labels applied on namespace to mark them valid/invalid for openfaas functions
+ */
+type FakeLabeller struct {
+	FakeLabels map[string]string
+}
+
+func (s *FakeLabeller) Labels(ctx context.Context, namespace string) (map[string]string, error) {
+	return s.FakeLabels, nil
+}


### PR DESCRIPTION
Signed-off-by: Nitishkumar Singh <nitishkumarsingh71@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->
FIxes the list secret issue for namespace with no secret
## Description
<!--- Describe your changes in detail -->
The current faasd implementation included bug due to which, we receive error while listing secrets for any namespace which don't have any secret created.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change **this is required**
Resolve #220 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
1. Build and deploy the local binary
2. Create a new namespace
```
sudo ctr namespace create test-ns
sudo ctr namespace label test-ns openfaas=true
```
3. List secrets using faas-cli, which provides output `No secrets found.`
```
faas-cli secret ls --namespace openfaas-fn
faas-cli secret ls --namespace test-ns
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Commits:

- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] My commit message has a body and describe how this was tested and why it is required.
- [x] I have signed-off my commits with `git commit -s` for the Developer Certificate of Origin (DCO)

Code:

- [x] My code follows the code style of this project.
- [x] I have added tests to cover my changes.

Docs:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
