### PR TITLE
Create volumes automatically for NATS/Prometheus

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -12,7 +12,7 @@ jobs:
       GO111MODULE: off
     strategy:
       matrix:
-        go-version: [1.16.x]
+        go-version: [1.17.x]
         os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -9,7 +9,7 @@ jobs:
   publish:
     strategy:
       matrix:
-        go-version: [ 1.16.x ]
+        go-version: [ 1.17.x ]
         os: [ ubuntu-latest ]
     runs-on: ${{ matrix.os }}
     steps:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -20,21 +20,36 @@ services:
 
   nats:
     image: docker.io/library/nats-streaming:0.22.0
+# nobody
+    user: "65534"
     command:
       - "/nats-streaming-server"
       - "-m"
       - "8222"
-      - "--store=memory"
+      - "--store=file"
+      - "--dir=/nats"
       - "--cluster_id=faas-cluster"
+    volumes:
+# Data directory
+      - type: bind
+        source: ./nats
+        target: /nats
     # ports:
     #    - "127.0.0.1:8222:8222"
 
   prometheus:
     image: docker.io/prom/prometheus:v2.14.0
+# nobody
+    user: "65534"
     volumes:
+# Config directory
       - type: bind
         source: ./prometheus.yml
         target: /etc/prometheus/prometheus.yml
+# Data directory
+      - type: bind
+        source: ./prometheus
+        target: /prometheus
     cap_add:
       - CAP_NET_RAW
     ports:


### PR DESCRIPTION
Signed-off-by: Alex Ellis (OpenFaaS Ltd) <alexellis2@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Create volumes automatically for NATS/Prometheus

## Motivation and Context

Fixes: #223

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested by checking the logs of Prometheus and NATS was tested
by running async requests with hey then restarting faasd,
which deletes the NATS and queue-worker containers. The work
left over in the queue was restarted as expected.

Pre-created volumes are read from docker-compose.yaml and
only numeric user IDs are supported at this time. Users
can still specify a textual username, if they create the
source directory for a mount before restarting faasd,
it won't try to overwrite the directory.

Add comment for workingDirectoryPermission

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
