### PR TITLE
Improve readability of faasd logs

### DIFF
--- a/cmd/up.go
+++ b/cmd/up.go
@@ -16,6 +16,7 @@ import (
 	"github.com/spf13/cobra"
 	flag "github.com/spf13/pflag"
 
+	units "github.com/docker/go-units"
 	"github.com/openfaas/faasd/pkg"
 )
 
@@ -68,7 +69,7 @@ func runUp(cmd *cobra.Command, _ []string) error {
 		return err
 	}
 
-	log.Printf("Supervisor created in: %s\n", time.Since(start).String())
+	log.Printf("Supervisor created in: %s\n", units.HumanDuration(time.Since(start)))
 
 	start = time.Now()
 	if err := supervisor.Start(services); err != nil {
@@ -76,7 +77,7 @@ func runUp(cmd *cobra.Command, _ []string) error {
 	}
 	defer supervisor.Close()
 
-	log.Printf("Supervisor init done in: %s\n", time.Since(start).String())
+	log.Printf("Supervisor init done in: %s\n", units.HumanDuration(time.Since(start)))
 
 	shutdownTimeout := time.Second * 1
 	timeout := time.Second * 60

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/docker/distribution v2.8.0+incompatible
 	github.com/docker/docker v17.12.0-ce-rc1.0.20191113042239-ea84732a7725+incompatible // indirect
 	github.com/docker/docker-credential-helpers v0.6.3 // indirect
+	github.com/docker/go-units v0.4.0
 	github.com/gorilla/mux v1.8.0
 	github.com/morikuni/aec v1.0.0
 	github.com/opencontainers/runtime-spec v1.0.3-0.20200929063507-e6143ca7d51d

--- a/pkg/supervisor.go
+++ b/pkg/supervisor.go
@@ -24,6 +24,7 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/containerd/containerd/namespaces"
+	units "github.com/docker/go-units"
 	"github.com/opencontainers/runtime-spec/specs-go"
 )
 
@@ -112,7 +113,7 @@ func (s *Supervisor) Start(svcs []Service) error {
 		}
 		images[svc.Name] = img
 		size, _ := img.Size(ctx)
-		fmt.Printf("Prepare done for: %s, %d bytes\n", svc.Image, size)
+		fmt.Printf("Prepare done for: %s, %s\n", svc.Image, units.HumanSize(float64(size)))
 	}
 
 	for _, svc := range svcs {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -151,6 +151,7 @@ github.com/docker/go-connections/nat
 # github.com/docker/go-events v0.0.0-20190806004212-e31b211e4f1c
 github.com/docker/go-events
 # github.com/docker/go-units v0.4.0
+## explicit
 github.com/docker/go-units
 # github.com/gogo/googleapis v1.4.0
 github.com/gogo/googleapis/google/rpc


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Improve log readability for faasd:
- print start-up timings as a human-readable approximation of a duration. 
- print download size of images in a human-readable approximation of a size capped at 4 valid numbers.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change **this is required**
closes #252
closes #251


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
1. Build and deploy the local binary
2. Show the logs for faasd
  `journalctl -u faasd`

Example output:
<img width="789" alt="image" src="https://user-images.githubusercontent.com/16267532/161377939-c316501f-4804-4e59-b75e-3463cb07cde6.png">



## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Commits:

- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] My commit message has a body and describe how this was tested and why it is required.
- [x] I have signed-off my commits with `git commit -s` for the Developer Certificate of Origin (DCO)

Code:

- [x] My code follows the code style of this project.
- [ ] I have added tests to cover my changes.

Docs:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
