### PR TITLE
Normalize image name

### DIFF
--- a/pkg/supervisor.go
+++ b/pkg/supervisor.go
@@ -19,6 +19,7 @@ import (
 	"github.com/containerd/containerd/containers"
 	"github.com/containerd/containerd/oci"
 	gocni "github.com/containerd/go-cni"
+	"github.com/docker/distribution/reference"
 	"github.com/openfaas/faasd/pkg/cninetwork"
 	"github.com/openfaas/faasd/pkg/service"
 	"github.com/pkg/errors"
@@ -107,7 +108,14 @@ func (s *Supervisor) Start(svcs []Service) error {
 	for _, svc := range svcs {
 		fmt.Printf("Preparing %s with image: %s\n", svc.Name, svc.Image)
 
-		img, err := service.PrepareImage(ctx, s.client, svc.Image, defaultSnapshotter, faasServicesPullAlways)
+		r, err := reference.ParseNormalizedNamed(svc.Image)
+		if err != nil {
+			return err
+		}
+
+		imgRef := reference.TagNameOnly(r).String()
+
+		img, err := service.PrepareImage(ctx, s.client, imgRef, defaultSnapshotter, faasServicesPullAlways)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Normalize the image names of services the same way as we do for function images.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change **this is required**
closes #247 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
1. Started a new multipass instance and installed the local faasd binary
2. Prepared an image on the host machine.
```
# pull the figlet image
docker pull ghcr.io/openfaas/figlet:latest

# save the image to a tar archive
docker image save figlet:latest -o figlet.tar

# copy the image to the multipass instance
multipass transfer ./figlet.tar faasd:figlet.tar
```
3. Imported the image on the multipass instance using `ctr`.
```
sudo ctr -n openfaas image import ./figlet.tar
```
4. Added a service in `/var/lib/faasd/docker-compose.yaml`
```
figlet:
    # reference the image with the familiar name
    image: figlet:latest
    cap_add:
      - CAP_NET_RAW
    ports:
      - "6000:8080"
```
5. Restarted faasd
```
sudo systemctl daemon-reload && sudo systemctl restart faasd
```
<details>
<summary>faasd logs:</summary>

```
Apr 11 12:35:59 faasd systemd[1]: Started faasd.
Apr 11 12:36:00 faasd faasd[9350]: faasd version: dev        commit:
Apr 11 12:36:00 faasd faasd[9350]: 2022/04/11 12:36:00 File exists: "/var/lib/faasd/secrets/basic-auth-password"
Apr 11 12:36:00 faasd faasd[9350]: 2022/04/11 12:36:00 File exists: "/var/lib/faasd/secrets/basic-auth-user"
Apr 11 12:36:00 faasd faasd[9350]: 2022/04/11 12:36:00 Writing network config...
Apr 11 12:36:00 faasd faasd[9350]: 2022/04/11 12:36:00 Supervisor created in: Less than a second
Apr 11 12:36:00 faasd faasd[9350]: Preparing nats with image: docker.io/library/nats-streaming:0.22.0
Apr 11 12:36:00 faasd faasd[9350]: Prepare done for: docker.io/library/nats-streaming:0.22.0, 6.804MB
Apr 11 12:36:00 faasd faasd[9350]: Preparing prometheus with image: docker.io/prom/prometheus:v2.14.0
Apr 11 12:36:00 faasd faasd[9350]: Prepare done for: docker.io/prom/prometheus:v2.14.0, 53.53MB
Apr 11 12:36:00 faasd faasd[9350]: Preparing gateway with image: ghcr.io/openfaas/gateway:0.21.3
Apr 11 12:36:00 faasd faasd[9350]: Prepare done for: ghcr.io/openfaas/gateway:0.21.3, 11.86MB
Apr 11 12:36:00 faasd faasd[9350]: Preparing queue-worker with image: ghcr.io/openfaas/queue-worker:0.12.2
Apr 11 12:36:00 faasd faasd[9350]: Prepare done for: ghcr.io/openfaas/queue-worker:0.12.2, 3.031MB
Apr 11 12:36:00 faasd faasd[9350]: Preparing figlet with image: figlet:latest
Apr 11 12:36:00 faasd faasd[9350]: Prepare done for: figlet:latest, 12.12MB
Apr 11 12:36:00 faasd faasd[9350]: Preparing basic-auth-plugin with image: ghcr.io/openfaas/basic-auth:0.21.0
Apr 11 12:36:00 faasd faasd[9350]: Prepare done for: ghcr.io/openfaas/basic-auth:0.21.0, 7.319MB
Apr 11 12:36:00 faasd faasd[9350]: Removing old container for: nats
Apr 11 12:36:00 faasd faasd[9350]: Removing old container for: prometheus
Apr 11 12:36:00 faasd faasd[9350]: 2022/04/11 12:36:00 Status of prometheus is: stopped
Apr 11 12:36:00 faasd faasd[9350]: 2022/04/11 12:36:00 Need to kill task: prometheus
Apr 11 12:36:00 faasd faasd[9350]: Removing old container for: gateway
Apr 11 12:36:00 faasd faasd[9350]: 2022/04/11 12:36:00 Status of gateway is: running
Apr 11 12:36:00 faasd faasd[9350]: 2022/04/11 12:36:00 Need to kill task: gateway
Apr 11 12:36:00 faasd faasd[9350]: Removing old container for: queue-worker
Apr 11 12:36:00 faasd faasd[9350]: Removing old container for: figlet
Apr 11 12:36:00 faasd faasd[9350]: Removing old container for: basic-auth-plugin
Apr 11 12:36:00 faasd faasd[9350]: 2022/04/11 12:36:00 Start-up order:
Apr 11 12:36:00 faasd faasd[9350]: 2022/04/11 12:36:00 - nats
Apr 11 12:36:00 faasd faasd[9350]: 2022/04/11 12:36:00 - prometheus
Apr 11 12:36:00 faasd faasd[9350]: 2022/04/11 12:36:00 - basic-auth-plugin
Apr 11 12:36:00 faasd faasd[9350]: 2022/04/11 12:36:00 - gateway
Apr 11 12:36:00 faasd faasd[9350]: 2022/04/11 12:36:00 - queue-worker
Apr 11 12:36:00 faasd faasd[9350]: 2022/04/11 12:36:00 - figlet
Apr 11 12:36:00 faasd faasd[9350]: Starting: nats
Apr 11 12:36:00 faasd faasd[9350]: Creating local directory: /var/lib/faasd/nats
Apr 11 12:36:00 faasd faasd[9350]: 2022/04/11 12:36:00 Running nats with user: "65534"
Apr 11 12:36:00 faasd faasd[9350]: 2022/04/11 12:36:00 Created container: nats
Apr 11 12:36:00 faasd faasd[9350]: 2022/04/11 12:36:00 nats has IP: 10.62.0.7
Apr 11 12:36:00 faasd faasd[9350]: 2022/04/11 12:36:00 Task: nats        Container: nats
Apr 11 12:36:00 faasd faasd[9350]: Starting: prometheus
Apr 11 12:36:00 faasd faasd[9350]: Creating local directory: /var/lib/faasd/prometheus
Apr 11 12:36:00 faasd faasd[9350]: 2022/04/11 12:36:00 Running prometheus with user: "65534"
Apr 11 12:36:00 faasd faasd[9350]: 2022/04/11 12:36:00 Created container: prometheus
Apr 11 12:36:00 faasd faasd[9350]: 2022/04/11 12:36:00 prometheus has IP: 10.62.0.8
Apr 11 12:36:00 faasd faasd[9350]: 2022/04/11 12:36:00 Task: prometheus        Container: prometheus
Apr 11 12:36:00 faasd faasd[9350]: Starting: basic-auth-plugin
Apr 11 12:36:00 faasd faasd[9350]: 2022/04/11 12:36:00 Created container: basic-auth-plugin
Apr 11 12:36:01 faasd faasd[9350]: 2022/04/11 12:36:01 basic-auth-plugin has IP: 10.62.0.9
Apr 11 12:36:01 faasd faasd[9350]: 2022/04/11 12:36:01 Task: basic-auth-plugin        Container: basic-auth-plugin
Apr 11 12:36:01 faasd faasd[9350]: Starting: gateway
Apr 11 12:36:01 faasd faasd[9350]: 2022/04/11 12:36:01 Created container: gateway
Apr 11 12:36:01 faasd faasd[9350]: 2022/04/11 12:36:01 gateway has IP: 10.62.0.10
Apr 11 12:36:01 faasd faasd[9350]: 2022/04/11 12:36:01 Task: gateway        Container: gateway
Apr 11 12:36:01 faasd faasd[9350]: Starting: queue-worker
Apr 11 12:36:01 faasd faasd[9350]: 2022/04/11 12:36:01 Created container: queue-worker
Apr 11 12:36:01 faasd faasd[9350]: 2022/04/11 12:36:01 queue-worker has IP: 10.62.0.11
Apr 11 12:36:01 faasd faasd[9350]: 2022/04/11 12:36:01 Task: queue-worker        Container: queue-worker
Apr 11 12:36:01 faasd faasd[9350]: Starting: figlet
Apr 11 12:36:01 faasd faasd[9350]: 2022/04/11 12:36:01 Created container: figlet
Apr 11 12:36:01 faasd faasd[9350]: 2022/04/11 12:36:01 figlet has IP: 10.62.0.12
Apr 11 12:36:01 faasd faasd[9350]: 2022/04/11 12:36:01 Task: figlet        Container: figlet
Apr 11 12:36:01 faasd faasd[9350]: 2022/04/11 12:36:01 Supervisor init done in: 1 second
Apr 11 12:36:01 faasd faasd[9350]: 2022/04/11 12:36:01 Looking up IP for: "figlet"
Apr 11 12:36:01 faasd faasd[9350]: 2022/04/11 12:36:01 Looking up IP for: "prometheus"
Apr 11 12:36:01 faasd faasd[9350]: 2022/04/11 12:36:01 Resolver rebuilding map
Apr 11 12:36:01 faasd faasd[9350]: 2022/04/11 12:36:01 Resolver: "localhost"="127.0.0.1"
Apr 11 12:36:01 faasd faasd[9350]: 2022/04/11 12:36:01 Resolver: "faasd-provider"="10.62.0.1"
Apr 11 12:36:01 faasd faasd[9350]: 2022/04/11 12:36:01 Resolver: "nats"="10.62.0.7"
Apr 11 12:36:01 faasd faasd[9350]: 2022/04/11 12:36:01 Resolver: "prometheus"="10.62.0.8"
Apr 11 12:36:01 faasd faasd[9350]: 2022/04/11 12:36:01 Resolver: "basic-auth-plugin"="10.62.0.9"
Apr 11 12:36:01 faasd faasd[9350]: 2022/04/11 12:36:01 Resolver: "gateway"="10.62.0.10"
Apr 11 12:36:01 faasd faasd[9350]: 2022/04/11 12:36:01 Resolver: "queue-worker"="10.62.0.11"
Apr 11 12:36:01 faasd faasd[9350]: 2022/04/11 12:36:01 Resolver: "figlet"="10.62.0.12"
Apr 11 12:36:01 faasd faasd[9350]: 2022/04/11 12:36:01 Looking up IP for: "gateway"
Apr 11 12:36:01 faasd faasd[9350]: 2022/04/11 12:36:01 Proxy from: 0.0.0.0:8080, to: gateway:8080 (10.62.0.10)
Apr 11 12:36:01 faasd faasd[9350]: 2022/04/11 12:36:01 faasd: waiting for SIGTERM or SIGINT
Apr 11 12:36:02 faasd faasd[9350]: 2022/04/11 12:36:02 Proxy from: 127.0.0.1:9090, to: prometheus:9090 (10.62.0.8)
Apr 11 12:36:02 faasd faasd[9350]: 2022/04/11 12:36:02 Proxy from: 0.0.0.0:6000, to: figlet:8080 (10.62.0.12)
```

</details>

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Commits:

- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] My commit message has a body and describe how this was tested and why it is required.
- [x] I have signed-off my commits with `git commit -s` for the Developer Certificate of Origin (DCO)

Code:

- [x] My code follows the code style of this project.
- [ ] I have added tests to cover my changes.

Docs:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.