### PR TITLE
remove unused container client from createTask

### DIFF
--- a/pkg/provider/handlers/deploy.go
+++ b/pkg/provider/handlers/deploy.go
@@ -175,7 +175,7 @@ func deploy(ctx context.Context, req types.FunctionDeployment, client *container
 		return fmt.Errorf("unable to create container: %s, error: %w", name, err)
 	}
 
-	return createTask(ctx, client, container, cni)
+	return createTask(ctx, container, cni)
 
 }
 
@@ -203,7 +203,7 @@ func buildLabels(request *types.FunctionDeployment) (map[string]string, error) {
 	return labels, nil
 }
 
-func createTask(ctx context.Context, client *containerd.Client, container containerd.Container, cni gocni.CNI) error {
+func createTask(ctx context.Context, container containerd.Container, cni gocni.CNI) error {
 
 	name := container.ID()
 

--- a/pkg/provider/handlers/scale.go
+++ b/pkg/provider/handlers/scale.go
@@ -131,7 +131,7 @@ func MakeReplicaUpdateHandler(client *containerd.Client, cni gocni.CNI) func(w h
 		}
 
 		if createNewTask {
-			deployErr := createTask(ctx, client, ctr, cni)
+			deployErr := createTask(ctx, ctr, cni)
 			if deployErr != nil {
 				log.Printf("[Scale] error deploying %s, error: %s\n", name, deployErr)
 				http.Error(w, deployErr.Error(), http.StatusBadRequest)


### PR DESCRIPTION
## Description
I removed unused argument from createTask function

## Motivation and Context
Clean the code


## Types of changes
Cleaning the code

Commits:

- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] My commit message has a body and describe how this was tested and why it is required.
- [x] I have signed-off my commits with `git commit -s` for the Developer Certificate of Origin (DCO)




