### PR TITLE
Fix issue #265 with Terraform installation

### DIFF
--- a/cloud-config.txt
+++ b/cloud-config.txt
@@ -10,7 +10,7 @@ packages:
  - git
 
 runcmd:
-- curl -sfL https://raw.githubusercontent.com/openfaas/faasd/master/hack/install.sh | sh -s -
+- curl -sfL https://raw.githubusercontent.com/openfaas/faasd/master/hack/install.sh | bash -s -
 - systemctl status -l containerd --no-pager
 - journalctl -u faasd-provider --no-pager
 - systemctl status -l faasd-provider --no-pager

--- a/docs/bootstrap/digitalocean-terraform/cloud-config.tpl
+++ b/docs/bootstrap/digitalocean-terraform/cloud-config.tpl
@@ -6,4 +6,4 @@ echo ${gw_password} > /var/lib/faasd/secrets/basic-auth-password
 export FAASD_DOMAIN=${faasd_domain_name}
 export LETSENCRYPT_EMAIL=${letsencrypt_email}
 
-curl -sfL https://raw.githubusercontent.com/openfaas/faasd/master/hack/install.sh | sh -s -
+curl -sfL https://raw.githubusercontent.com/openfaas/faasd/master/hack/install.sh | bash -s -


### PR DESCRIPTION
Signed-off-by: Alex Ellis (OpenFaaS Ltd) <alexellis2@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Fix issue #265 with Terraform installation

## Motivation and Context

The downstream installation script needs to be run via
bash to support early failure modes using pipefail.
Thanks to @koffeinfrei for reporting this and testing a
fix.

## How Has This Been Tested?

Tested by @koffeinfrei

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
