### PR TITLE
Fix install script on CentOS

### DIFF
--- a/hack/install.sh
+++ b/hack/install.sh
@@ -6,6 +6,7 @@ set -e -x -o pipefail
 
 export OWNER="openfaas"
 export REPO="faasd"
+export ARKADE=/usr/local/bin/arkade
 
 version=""
 
@@ -51,7 +52,7 @@ install_required_packages() {
     $SUDO apt-get install -y curl runc bridge-utils iptables
   elif $(has_yum); then
     $SUDO yum check-update -y
-    $SUDO yum install -y curl runc
+    $SUDO yum install -y curl runc iptables-services
   elif $(has_pacman); then
     $SUDO pacman -Syy
     $SUDO pacman -Sy curl runc bridge-utils
@@ -68,13 +69,13 @@ install_arkade(){
 
 install_cni_plugins() {
   cni_version=v0.9.1
-  sudo arkade system install cni --version ${cni_version} --path /opt/cni/bin
+  $SUDO $ARKADE system install cni --version ${cni_version} --path /opt/cni/bin
 }
 
 install_containerd() {
   CONTAINERD_VER=v1.6.4
   $SUDO systemctl unmask containerd || :
-  sudo arkade system install containerd --systemd --version ${CONTAINERD_VER}
+  $SUDO $ARKADE system install containerd --systemd --version ${CONTAINERD_VER}
   sleep 5
 }
 


### PR DESCRIPTION
Signed-off-by: Han Verstraete (OpenFaaS Ltd) <han@openfaas.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Update install script to work on CentOS 9
- Use full path to arkade binary when running with sudo
- Install iptables



## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [ ] I have raised an issue to propose this change **this is required**
This was discussed here: https://github.com/openfaas/faasd/pull/261#issuecomment-1137489275

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Ran updated script on CentOS 9

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Commits:

- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] My commit message has a body and describe how this was tested and why it is required.
- [x] I have signed-off my commits with `git commit -s` for the Developer Certificate of Origin (DCO)

Code:

- [x] My code follows the code style of this project.
- [ ] I have added tests to cover my changes.

Docs:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
