### PR TITLE
Make progress silent for faas-cli install

### DIFF
--- a/hack/install.sh
+++ b/hack/install.sh
@@ -69,13 +69,13 @@ install_arkade(){
 
 install_cni_plugins() {
   cni_version=v0.9.1
-  $SUDO $ARKADE system install cni --version ${cni_version} --path /opt/cni/bin
+  $SUDO $ARKADE system install cni --version ${cni_version} --path /opt/cni/bin --progress=false
 }
 
 install_containerd() {
   CONTAINERD_VER=v1.6.4
   $SUDO systemctl unmask containerd || :
-  $SUDO $ARKADE system install containerd --systemd --version ${CONTAINERD_VER}
+  $SUDO $ARKADE system install containerd --systemd --version ${CONTAINERD_VER}  --progress=false
   sleep 5
 }
 
@@ -113,7 +113,7 @@ install_faasd() {
 install_caddy() {
   if [ ! -z "${FAASD_DOMAIN}" ]; then
     CADDY_VER=v2.4.3
-    arkade get caddy -v ${CADDY_VER}
+    arkade get --progress=false caddy -v ${CADDY_VER}
     $SUDO install -m 755 $HOME/.arkade/bin/caddy /usr/local/bin/
 
     $SUDO curl -fSLs https://raw.githubusercontent.com/caddyserver/dist/master/init/caddy.service --output /etc/systemd/system/caddy.service
@@ -148,7 +148,7 @@ EOF
 }
 
 install_faas_cli() {
-  arkade get faas-cli
+  arkade get --progress=false faas-cli
   $SUDO install -m 755 $HOME/.arkade/bin/faas-cli /usr/local/bin/
 }
 


### PR DESCRIPTION
Signed-off-by: Richard Gee <richard@technologee.co.uk>

## Description
A recent change to `arkade `makes is possible to toggle the download progress for `arkade get` calls.  As this defaults to true the current install script looks like this:

![image](https://user-images.githubusercontent.com/16418793/171410007-5480c885-6ddc-46e7-b620-6ed539ea15c8.png)

The desired mode is for this to be quiet.  This change implements `--progress false` for the faas-cli installation via arkade.

## Motivation and Context
A recent change to `arkade `makes is possible to toggle the download progress for `arkade get` calls.
This change implements `--progress false` for the faas-cli installation via arkade.

## How Has This Been Tested?
Multipass vm:
```
$ git clone https://github.com/rgee0/faasd.git && cd faasd
$ git checkout silentProgress
$ ./hack/install.sh
```
<img width="713" alt="image" src="https://user-images.githubusercontent.com/16418793/171414638-481701db-39c8-474e-8760-2bd99afc85c2.png">


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Commits:

- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] My commit message has a body and describe how this was tested and why it is required.
- [x] I have signed-off my commits with `git commit -s` for the Developer Certificate of Origin (DCO)

Code:

- [x] My code follows the code style of this project.
- [ ] I have added tests to cover my changes.

Docs:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
