### PR TITLE
set HOME variable when not available, e.g when running with cloud-init

### DIFF
--- a/hack/install.sh
+++ b/hack/install.sh
@@ -12,6 +12,13 @@ export REPO="faasd"
 # to the arkade binary. 
 export ARKADE=/usr/local/bin/arkade
 
+# When running as a startup script (cloud-init), the HOME variable is not always set.
+# As it is required for arkade to properly download tools, 
+# set the variable to /usr/local so arkade will download binaries to /usr/local/.arkade
+if [ -z "${HOME}" ]; then
+  export HOME=/usr/local
+fi
+
 version=""
 
 echo "Finding latest version from GitHub"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Apparently, HOME variable isn't always set when cloud-init executes a startup script, causing the install.sh script to fail. This PR adds an additional check to see if this is the case and sets the variable if required.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change **this is required**
fixes #282 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Launched multiple VMs, locally with lima or mulitpass and on different cloud providers (GPC and AWS using Terraform) with this updated install script.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Commits:

- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [ ] My commit message has a body and describe how this was tested and why it is required.
- [x] I have signed-off my commits with `git commit -s` for the Developer Certificate of Origin (DCO)

Code:

- [ ] My code follows the code style of this project.
- [ ] I have added tests to cover my changes.

Docs:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
