### PR TITLE
Updated install docs (sed) to accept keys with `/` in them

### DIFF
--- a/docs/MULTIPASS.md
+++ b/docs/MULTIPASS.md
@@ -37,7 +37,7 @@ It took me about 2-3 minutes to run through everything after installing multipas
     This command will update the key with your local public key value and start the VM.
 
     ```sh
-    sed "s/ssh-rsa.*/$(cat $HOME/.ssh/id_*.pub)/" cloud-config.txt | multipass launch --name faasd --cloud-init -
+    sed "s/ssh-rsa.*/$(cat $HOME/.ssh/id_*.pub | sed 's/\//\\\//g')/" cloud-config.txt | multipass launch --name faasd --cloud-init -
     ```
 
     This can also be done manually, just replace the 2nd line of the `cloud-config.txt` with the coPntents of your public ssh key, usually either `~/.ssh/id_rsa.pub` or `~/.ssh/id_ed25519.pub`


### PR DESCRIPTION
## Description
Escaped the `/`s in the public key (sed command parameter)

## Motivation and Context
I encountered an issue installing faasd, my key had multiple `/`s in it.

## How Has This Been Tested?
My installation worked with the change

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Commits:

- [X] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [X] My commit message has a body and describe how this was tested and why it is required.
- [X] I have signed-off my commits with `git commit -s` for the Developer Certificate of Origin (DCO)

Code:

- [ ] My code follows the code style of this project.
- [ ] I have added tests to cover my changes.

Docs:

- [ ] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
