### PR TITLE
Fix installation script for containerd on armhf

### DIFF
--- a/hack/install.sh
+++ b/hack/install.sh
@@ -84,9 +84,21 @@ install_cni_plugins() {
 }
 
 install_containerd() {
-  CONTAINERD_VER=v1.6.4
+
   $SUDO systemctl unmask containerd || :
-  $SUDO $ARKADE system install containerd --systemd --version ${CONTAINERD_VER}  --progress=false
+
+  CONTAINERD_VER=1.6.4
+  arch=$(uname -m)
+  if[ $arch == "armv7l"]; then
+    $SUDO curl -fSLs "https://github.com/alexellis/containerd-arm/releases/download/v${version}/containerd-${version}-linux-armhf.tar.gz" --output "/tmp/containerd.tar.gz"
+    $SUDO tar -xvf /tmp/containerd.tar.gz -C /usr/local/bin/
+    $SUDO curl -fSLs https://raw.githubusercontent.com/containerd/containerd/v${version}/containerd.service --output "/etc/systemd/system/containerd.service"
+    $SUDO systemctl enable containerd
+    $SUDO systemctl start containerd
+  else
+    $SUDO $ARKADE system install containerd --systemd --version v${CONTAINERD_VER}  --progress=false
+  fi
+  
   sleep 5
 }
 


### PR DESCRIPTION
Signed-off-by: Alex Ellis (OpenFaaS Ltd) <alexellis2@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Fix installation script for containerd on armhf, by downloading from alexellis/containerd-arm as per previous script version - https://github.com/openfaas/faasd/commit/a88997e42c99e0b0d2779c7be99babf75dd550ae

## Motivation and Context

Fixes #295 

## How Has This Been Tested?

I need some help with testing this.
