### PR TITLE
Fix installation script for containerd on armhf

### DIFF
--- a/hack/install.sh
+++ b/hack/install.sh
@@ -84,9 +84,21 @@ install_cni_plugins() {
 }
 
 install_containerd() {
-  CONTAINERD_VER=v1.6.4
+
   $SUDO systemctl unmask containerd || :
-  $SUDO $ARKADE system install containerd --systemd --version ${CONTAINERD_VER}  --progress=false
+
+  CONTAINERD_VER=1.6.4
+  arch=$(uname -m)
+  if [ $arch == "armv7l" ]; then
+    $SUDO curl -fSLs "https://github.com/alexellis/containerd-arm/releases/download/v${CONTAINERD_VER}/containerd-${CONTAINERD_VER}-linux-armhf.tar.gz" --output "/tmp/containerd.tar.gz"
+    $SUDO tar -xvf /tmp/containerd.tar.gz -C /usr/local/bin/
+    $SUDO curl -fSLs https://raw.githubusercontent.com/containerd/containerd/v${CONTAINERD_VER}/containerd.service --output "/etc/systemd/system/containerd.service"
+    $SUDO systemctl enable containerd
+    $SUDO systemctl start containerd
+  else
+    $SUDO $ARKADE system install containerd --systemd --version v${CONTAINERD_VER}  --progress=false
+  fi
+  
   sleep 5
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Fix installation script for containerd on armhf, by downloading from alexellis/containerd-arm as per previous script version - https://github.com/openfaas/faasd/commit/a88997e42c99e0b0d2779c7be99babf75dd550ae

The script also requires an updated version of arkade to support the cni system app on armhf:
https://github.com/alexellis/arkade/releases/tag/0.8.34

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fixes https://github.com/openfaas/faasd/issues/295
Closes  #296

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested installation script with updated arkade version on pi3 running 32-bit Raspberry Pi OS lite.

Verified status with
```
sudo journalctl -u faasd --lines 100 -f
```

Deployed and invoked figlet function from store


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Commits:

- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [ ] My commit message has a body and describe how this was tested and why it is required.
- [x] I have signed-off my commits with `git commit -s` for the Developer Certificate of Origin (DCO)

Code:

- [ ] My code follows the code style of this project.
- [ ] I have added tests to cover my changes.

Docs:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
