### PR TITLE
Replace shasum -a 256 with sha256sum in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ dist:
 
 .PHONY: hashgen
 hashgen:
-	for f in bin/faasd*; do shasum -a 256 $$f > $$f.sha256; done
+	for f in bin/faasd*; do sha256sum $$f > $$f.sha256; done
 
 .PHONY: prepare-test
 prepare-test:


### PR DESCRIPTION
Signed-off-by: Gleb Sinyavskiy <zhulik.gleb@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Makefile uses shasum to calculate checksums of binaries, shasum is a part of perl package(on Archlinux and perl-utils on alpine) which makes perl a build dependency.

This PR replaces `shasum` with `sha256sum` which is a part of coreutiles package and is preinstalled almost everywhere.
 which means one needs perl installed to use the Makefile.
`sha256sum` has absolutely similar output  as `shasum -a 256` but does not require perl to be installed

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [ ] I have raised an issue to propose this change **this is required**


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Commits:

- [ ] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [ ] My commit message has a body and describe how this was tested and why it is required.
- [ ] I have signed-off my commits with `git commit -s` for the Developer Certificate of Origin (DCO)

Code:

- [ ] My code follows the code style of this project.
- [ ] I have added tests to cover my changes.

Docs:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
