### PR TITLE
Removed auth plugin

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,27 +1,6 @@
 version: "3.7"
 services:
 
-  # AE: The basic-auth-plugin is deprecated for OpenFaaS CE
-  # and will be removed in a future release. The behaviour is 
-  # now part of the gateway itself.
-  basic-auth-plugin:
-    image: ghcr.io/openfaas/basic-auth:0.25.5
-    environment:
-      - port=8080
-      - secret_mount_path=/run/secrets
-      - user_filename=basic-auth-user
-      - pass_filename=basic-auth-password
-    volumes:
-      # we assume cwd == /var/lib/faasd
-      - type: bind
-        source: ./secrets/basic-auth-password
-        target: /run/secrets/basic-auth-password
-      - type: bind
-        source: ./secrets/basic-auth-user
-        target: /run/secrets/basic-auth-user
-    cap_add:
-      - CAP_NET_RAW
-
   nats:
     image: docker.io/library/nats-streaming:0.25.3
 # nobody
@@ -70,8 +49,6 @@ services:
       - upstream_timeout=65s
       - faas_nats_address=nats
       - faas_nats_port=4222
-      - auth_proxy_url=http://basic-auth-plugin:8080/validate
-      - auth_proxy_pass_body=false
       - secret_mount_path=/run/secrets
       - scale_from_zero=true
       - function_namespace=openfaas-fn
@@ -86,7 +63,6 @@ services:
     cap_add:
       - CAP_NET_RAW
     depends_on:
-      - basic-auth-plugin
       - nats
       - prometheus
     ports:


### PR DESCRIPTION
Signed-off-by: Nitishkumar Singh <nitishkumarsingh71@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Auth has been included in  gateway itself, so `auth-plugin` is not required.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change **this is required**
Closes #314 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
1. Install using `hack/install.sh`
2. Login to faasd `sudo cat /var/lib/faasd/secrets/basic-auth-password | faas-cli login -s`
```
Calling the OpenFaaS server to validate the credentials...
credentials saved for admin http://127.0.0.1:8080
```
3. Deploy function `faas-cli deploy --image ghcr.io/openfaas/figlet:latest --name figlet`
```
Deployed. 200 OK.
URL: http://127.0.0.1:8080/function/figlet
```
4. List functions `faas-cli ls`
```
Function                      	Invocations    	Replicas
figlet                        	0              	1    
```



## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Commits:

- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] My commit message has a body and describe how this was tested and why it is required.
- [x] I have signed-off my commits with `git commit -s` for the Developer Certificate of Origin (DCO)

Code:

- [x] My code follows the code style of this project.
- [ ] I have added tests to cover my changes.

Docs:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
