### PR TITLE
Enable quicker shutdown

### DIFF
--- a/cmd/up.go
+++ b/cmd/up.go
@@ -92,6 +92,7 @@ func runUp(cmd *cobra.Command, _ []string) error {
 		<-sig
 
 		log.Printf("Signal received.. shutting down server in %s\n", shutdownTimeout.String())
+
 		err := supervisor.Remove(services)
 		if err != nil {
 			fmt.Println(err)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Enable quicker shutdown

When `write_timeout: 30s` is set to a long value, the function can hang when being removed with certain templates i.e. golang-middleware

## Motivation and Context

Reduces default grace period from 30s to 5s for removing functions.

The `healthcheck_interval` env-var can be used to override the value and set it higher or lower.

At times, removing a function will hang or fail, and is confusing to users.

## How Has This Been Tested?

No testing yet, beyond building the code

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
