### PR TITLE
mark namespace with label openfaas=1 valid

### DIFF
--- a/pkg/provider/handlers/utils.go
+++ b/pkg/provider/handlers/utils.go
@@ -39,7 +39,8 @@ func validNamespace(store provider.Labeller, namespace string) (bool, error) {
 		return false, err
 	}
 
-	if value, found := labels[pkg.NamespaceLabel]; found && value == "true" {
+	// check for true to keep it backward compatible
+	if value, found := labels[pkg.NamespaceLabel]; found && (value == "true" || value == "1") {
 		return true, nil
 	}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
`faasd` implementation was no allowing to deploy functions into namespace with label `openfaas=1`. Instead code was written to validate `openfaas=true`.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change **this is required**
Closes #351 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
1. Create and install a local build of faasd binary using `make local`
2. Run the below script to deploy functions with label `openfaas=1`. Script is using `go-sdk` which includes label `openfaas=1` for any new namespace created.
```
package main

import (
	"context"
	"fmt"
	"log"
	"net/http"
	"net/url"
	"os"
	"time"

	"github.com/openfaas/faas-provider/types"
	"github.com/openfaas/go-sdk"
)

func main() {
	username := os.Getenv("OPENFAAS_USERNAME")
	password := os.Getenv("OPENFAAS_PASSWORD")

	gatewayURL, _ := url.Parse(os.Getenv("OPENFAAS_GATEWAY_URL"))
	auth := &sdk.BasicAuth{
		Username: username,
		Password: password,
	}
	nsName := "test-sdk-ns"
	fnName := "env-store-test"

	client := sdk.NewClient(gatewayURL, auth, http.DefaultClient)

	// create namespace
	_, err := client.CreateNamespace(context.Background(), types.FunctionNamespace{
		Name: nsName,
		Labels: map[string]string{
			"purpose": "test",
		},
	})

	if err != nil {
		log.Fatalf("Namespace creation Failed: %s\n", err)
	}
	fmt.Printf("Namespace %s created!\n", nsName)

	// get namespace
	res, err := client.GetNamespace(context.Background(), nsName)

	if err != nil {
		log.Fatalf("Namespace get Failed: %s\n", err)
	}

	fmt.Printf("GetNamespace: %q\n", res)

	// update namespace
	_, err = client.UpdateNamespace(context.Background(), types.FunctionNamespace{
		Name: nsName,
		Labels: map[string]string{
			"purpose": "test",
			"demo":    "false",
		},
		Annotations: map[string]string{
			"anno": "true",
		},
	})

	if err != nil {
		log.Fatalf("Namespace update Failed: %s\n", err)
	}

	res, err = client.GetNamespace(context.Background(), nsName)

	if err != nil {
		log.Fatalf("Namespace get Failed: %s\n", err)
	}

	demo, found := res.Labels["demo"]

	if !found || demo != "false" {
		log.Fatalf("Namespace update Failed: %s\n", err)
	}
	fmt.Printf("Updated Namespace: %q\n", res)

	// get namespaces
	namespaces, err := client.GetNamespaces(context.Background())
	fmt.Printf("Namespaces: %q\n", namespaces)

	// deploy
	_, err = client.Deploy(context.Background(), types.FunctionDeployment{
		Service:    fnName,
		Image:      "ghcr.io/openfaas/alpine:latest",
		Namespace:  nsName,
		EnvProcess: "env",
	})

	if err != nil {
		log.Fatalf("Deploy Failed: %s\n", err)
	}
	fmt.Printf("Deploy Completed!\n")

	fmt.Printf("Sleep....\n")
	time.Sleep(15 * time.Second)
	fmt.Printf("Sleep Finish\n")

	fn, err := client.GetFunction(context.Background(), fnName, nsName)
	fmt.Printf("Function: %v\n", fn)
	if err != nil {
		log.Fatalf("GetFunction Failed: %s\n", err)
	}

	// fmt.Println("Scale to Zero")
	// err = client.ScaleFunction(context.Background(), fnName, nsName, 0)
	// if err != nil {
	// 	log.Fatalf("ScaleFunction Failed: %s\n", err)
	// }

	// fmt.Printf("Sleep....\n")
	// time.Sleep(15 * time.Second)
	// fmt.Printf("Sleep Finish\n\n\n\n")

	// // delete
	// err = client.DeleteFunction(context.Background(), fnName, nsName)
	// if err != nil {
	// 	log.Fatalf("DeleteFunction Failed: %s\n", err)
	// }
	// fmt.Print("Function Deleted!\n\n\n\n")

	// // delete namespace
	// err = client.DeleteNamespace(context.Background(), nsName)
	// if err != nil {
	// 	log.Fatalf("Namespace %s delete Failed: %s\n", nsName, err)
	// }
	// fmt.Printf("Namespace %s deleted!\n\n\n\n", nsName)
}
```
3. Below output was produced for the above script
```
Namespace test-sdk-ns created!
GetNamespace: {"test-sdk-ns" map[] map["openfaas":"1" "purpose":"test"]}
Updated Namespace: {"test-sdk-ns" map[] map["demo":"false" "openfaas":"1" "purpose":"test"]}
Namespaces: ["openfaas-fn" "test-sdk-ns"]
Deploy Completed!
Sleep....
Sleep Finish
Function: {env-store-test ghcr.io/openfaas/alpine:latest test-sdk-ns env map[] [] [] 0xc000014228 0xc000014230 <nil> <nil> false 0 1 1 2023-11-28 20:50:06.077724974 +0000 UTC <nil>}
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Commits:

- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] My commit message has a body and describe how this was tested and why it is required.
- [x] I have signed-off my commits with `git commit -s` for the Developer Certificate of Origin (DCO)

Code:

- [x] My code follows the code style of this project.
- [ ] I have added tests to cover my changes.

Docs:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
