### PR TITLE
Fix sometimes the faas container cannot be started

### DIFF
--- a/pkg/constants.go
+++ b/pkg/constants.go
@@ -10,6 +10,9 @@ const (
 	// FaasdNamespace is the containerd namespace services are created
 	FaasdNamespace = "openfaas"
 
+	// DefaultSnapshotNameSuffix is the default suffix for snapshot names
+	DefaultSnapshotNameSuffix = "-snapshot"
+
 	faasServicesPullAlways = false
 
 	defaultSnapshotter = "overlayfs"

--- a/pkg/provider/handlers/deploy.go
+++ b/pkg/provider/handlers/deploy.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/openfaas/faasd/pkg"
 	"io/ioutil"
 	"log"
 	"net/http"
@@ -161,7 +162,7 @@ func deploy(ctx context.Context, req types.FunctionDeployment, client *container
 		name,
 		containerd.WithImage(image),
 		containerd.WithSnapshotter(snapshotter),
-		containerd.WithNewSnapshot(name+"-snapshot", image),
+		containerd.WithNewSnapshot(name+pkg.DefaultSnapshotNameSuffix, image),
 		containerd.WithNewSpec(oci.WithImageConfig(image),
 			oci.WithHostname(name),
 			oci.WithCapabilities([]string{"CAP_NET_RAW"}),

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -3,6 +3,7 @@ package service
 import (
 	"context"
 	"fmt"
+	"github.com/openfaas/faasd/pkg"
 	"log"
 	"os"
 	"path/filepath"
@@ -57,7 +58,7 @@ func Remove(ctx context.Context, client *containerd.Client, name string) error {
 
 	} else {
 		service := client.SnapshotService("")
-		key := name + "snapshot"
+		key := name + pkg.DefaultSnapshotNameSuffix
 		if _, err := client.SnapshotService("").Stat(ctx, key); err == nil {
 			service.Remove(ctx, key)
 		}

--- a/pkg/supervisor.go
+++ b/pkg/supervisor.go
@@ -217,7 +217,7 @@ func (s *Supervisor) Start(svcs []Service) error {
 			ctx,
 			svc.Name,
 			containerd.WithImage(image),
-			containerd.WithNewSnapshot(svc.Name+"-snapshot", image),
+			containerd.WithNewSnapshot(svc.Name+DefaultSnapshotNameSuffix, image),
 			containerd.WithNewSpec(oci.WithImageConfig(image),
 				oci.WithHostname(svc.Name),
 				withUserOrDefault(svc.User),


### PR DESCRIPTION
When obtaining the container information fails, the key for deleting the snapshot is incorrect

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [ ] I have raised an issue to propose this change **this is required**


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Commits:

- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] My commit message has a body and describe how this was tested and why it is required.
- [x] I have signed-off my commits with `git commit -s` for the Developer Certificate of Origin (DCO)

Code:

- [x] My code follows the code style of this project.
- [ ] I have added tests to cover my changes.

Docs:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
