### PR TITLE
Fix for proxy exiting early during start-up

### DIFF
--- a/pkg/proxy.go
+++ b/pkg/proxy.go
@@ -86,7 +86,7 @@ func (p *Proxy) Start() error {
 			conn.Close()
 
 			log.Printf("Unable to dial: %s, error: %s", upstreamAddr, err.Error())
-			return err
+			continue
 		}
 
 		go pipe(conn, upstream)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Fix for proxy exiting early during start-up

## Motivation and Context

When a proxied core service was accessed before it was ready to accept a connection, due to a start-up, restart, etc of a core service, then the proxy exited instead of continuing to accept new connections.

This meant having to restart faasd and hope the race condition worked itself out, or that no incoming requests were made.

Tested with Grafana, which seemed to manifest the issue the most.

```
Jan 30 08:58:09 derek faasd[1684930]: 2025/01/30 08:58:09 Proxy from: 127.0.0.1:8080, to: gateway:8080 (10.62.1.184)
Jan 30 08:58:09 derek faasd[1684930]: 2025/01/30 08:58:09 Proxy from: 127.0.0.1:8083, to: dashboard:8083 (10.62.1.185)
Jan 30 08:58:09 derek faasd[1684930]: 2025/01/30 08:58:09 Proxy from: 10.62.0.1:5432, to: postgresql:5432 (10.62.1.187)
Jan 30 08:58:09 derek faasd[1684930]: 2025/01/30 08:58:09 Proxy from: 127.0.0.1:9090, to: prometheus:9090 (10.62.1.183)
Jan 30 08:58:09 derek faasd[1684930]: 2025/01/30 08:58:09 Proxy from: 127.0.0.1:3000, to: grafana:3000 (10.62.1.189)
Jan 30 08:58:10 derek faasd[1684930]: 2025/01/30 08:58:10 Unable to dial: 10.62.1.189:3000, error: dial tcp 10.62.1.189:3000: connect: connection refused
```

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

After the fix, the warning is still logged, but the proxy continues to accept new connections.


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
