### PR TITLE
Fix OpenFaaS Edge install script for RHEL-based systems.

### DIFF
--- a/hack/install-edge.sh
+++ b/hack/install-edge.sh
@@ -13,8 +13,8 @@ if [ "$EUID" -ne 0 ]; then
     exit
 fi
 
-has_yum() {
-  [ -n "$(command -v yum)" ]
+has_dnf() {
+  [ -n "$(command -v dnf)" ]
 }
 
 has_apt_get() {
@@ -37,9 +37,8 @@ install_required_packages() {
     # reference: https://github.com/openfaas/faasd/pull/237
     apt-get update -yq
     apt-get install -yq curl runc bridge-utils iptables iptables-persistent
-  elif $(has_yum); then
-    yum check-update -y
-    yum install -y curl runc iptables-services which
+  elif $(has_dnf); then
+    dnf install -y curl runc iptables-services which
   elif $(has_pacman); then
     pacman -Syy
     pacman -Sy curl runc bridge-utils
@@ -60,6 +59,7 @@ if [ -z "$SKIP_OS" ]; then
     install_required_packages
 fi
 
+echo ""
 echo "2. Downloading OCI image, and installing pre-requisites"
 echo ""
 if [ ! -x "$(command -v arkade)" ]; then

--- a/hack/install-edge.sh
+++ b/hack/install-edge.sh
@@ -95,6 +95,17 @@ ${BINLOCATION}arkade oci install --path ${tmpdir} \
 cd ${tmpdir}
 ./install.sh ./
 
+if has_dnf; then
+  isRhelLike=true
+else
+  isRhelLike=false
+fi
+
+binaryName="faasd"
+if [ "$isRhelLike" = true ]; then
+  binaryName="/usr/local/bin/faasd"
+fi
+
 echo ""
 echo "3.1 Commercial users can create their license key as follows:"
 echo ""
@@ -103,12 +114,12 @@ echo "sudo nano /var/lib/faasd/secrets/openfaas_license"
 echo ""
 echo "3.2 For personal, non-commercial use only, GitHub Sponsors of @openfaas (25USD+) can run:"
 echo ""
-echo "sudo -E faasd github login"
-echo "sudo -E faasd activate"
+echo "sudo -E ${binaryName} github login"
+echo "sudo -E ${binaryName} activate"
 echo ""
 echo "4. Then perform the final installation steps"
 echo ""
-echo "sudo -E sh -c \"cd ${tmpdir}/var/lib/faasd && faasd install\""
+echo "sudo -E sh -c \"cd ${tmpdir}/var/lib/faasd && ${binaryName} install\""
 echo ""
 echo "5. Refer to the complete handbook and supplementary documentation at:"
 echo ""


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

This change removes the check-update command. This comand is not required and caused the script to exit early if packages are not up to date.

In addition DNF is now used to install packages. DNF is the successor of YUM on the latest RHEL-based systems.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [ ] I have raised an issue to propose this change **this is required**

This change fixes an issue with the install script on RHEL-based systems.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

The script has been verified on Rocky Linux 8 and 9.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Commits:

- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] My commit message has a body and describe how this was tested and why it is required.
- [x] I have signed-off my commits with `git commit -s` for the Developer Certificate of Origin (DCO)

Code:

- [x] My code follows the code style of this project.
- [ ] I have added tests to cover my changes.

Docs:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
