### PR TITLE
Fix faasd CE install script for RHEL-based systems

### DIFF
--- a/hack/install-edge.sh
+++ b/hack/install-edge.sh
@@ -38,7 +38,10 @@ install_required_packages() {
     apt-get update -yq
     apt-get install -yq curl runc bridge-utils iptables iptables-persistent
   elif $(has_dnf); then
-    dnf install -y --allowerasing curl runc iptables-services bridge-utils which
+    dnf install -y \
+      --allowerasing \
+      --setopt=install_weak_deps=False \
+      curl runc iptables-services bridge-utils which
   elif $(has_pacman); then
     pacman -Syy
     pacman -Sy curl runc bridge-utils

--- a/hack/install.sh
+++ b/hack/install.sh
@@ -47,8 +47,8 @@ verify_system() {
   fi
 }
 
-has_yum() {
-  [ -n "$(command -v yum)" ]
+has_dnf() {
+  [ -n "$(command -v dnf)" ]
 }
 
 has_apt_get() {
@@ -67,14 +67,16 @@ install_required_packages() {
     # reference: https://github.com/openfaas/faasd/pull/237
     $SUDO apt-get update -y
     $SUDO apt-get install -y curl runc bridge-utils iptables
-  elif $(has_yum); then
-    $SUDO yum check-update -y
-    $SUDO yum install -y curl runc iptables-services
+  elif $(has_dnf); then
+    $SUDO dnf install -y \
+      --allowerasing \
+      --setopt=install_weak_deps=False \
+      curl runc iptables-services bridge-utils
   elif $(has_pacman); then
     $SUDO pacman -Syy
     $SUDO pacman -Sy curl runc bridge-utils
   else
-    fatal "Could not find apt-get, yum, or pacman. Cannot install dependencies on this OS."
+    fatal "Could not find apt-get, dnf, or pacman. Cannot install dependencies on this OS."
     exit 1
   fi
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Fixes for `install.sh`:
  - Removes the check-update command. This comand is not required and caused the script to exit early if packages are not up to date.
  - DNF is now used to install packages. DNF is the successor of YUM on the latest RHEL-based systems.

Improvements for `install-edge.sh`:
- Don't install weak dependencies.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [ ] I have raised an issue to propose this change **this is required**

Fix install.sh script for RHEL-based systems.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Both `install.sh` and `install-edge.sh` have been tested on Rocky Linux 9.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Commits:

- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] My commit message has a body and describe how this was tested and why it is required.
- [x] I have signed-off my commits with `git commit -s` for the Developer Certificate of Origin (DCO)

Code:

- [x] My code follows the code style of this project.
- [ ] I have added tests to cover my changes.

Docs:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
